### PR TITLE
Make responses Responsable and return SuccessResponse from QueryBuilder

### DIFF
--- a/.github/scripts/setup-php.sh
+++ b/.github/scripts/setup-php.sh
@@ -5,14 +5,10 @@ sudo add-apt-repository ppa:ondrej/php
 sudo apt-get update
 sudo apt-get install -y \
     php${PHP_VERSION} \
-    php${PHP_VERSION}-curl \
-    php${PHP_VERSION}-cgi \
     php${PHP_VERSION}-cli \
     php${PHP_VERSION}-curl \
-    php${PHP_VERSION}-dev \
-    php${PHP_VERSION}-fpm \
     php${PHP_VERSION}-intl \
     php${PHP_VERSION}-mbstring \
-    php${PHP_VERSION}-mysql \
+    php${PHP_VERSION}-sqlite3 \
     php${PHP_VERSION}-xml \
     php${PHP_VERSION}-zip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,16 +27,6 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    services:
-      mysql:
-        image: mysql:8
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: yes
-          MYSQL_DATABASE: eufaturo_testing
-        ports:
-          - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
-
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -32,13 +32,11 @@ Use it in a controller:
 ```php
 final class ListController
 {
-    public function __invoke(Request $request, Response $response): JsonResponse
+    public function __invoke(Request $request)
     {
-        $products = QueryBuilder::for(Product::class, $request)
+        return QueryBuilder::for(Product::class, $request)
             ->fromResource(ProductResource::class)
             ->paginate();
-
-        return $response->success($products, ProductResource::class)->respond();
     }
 }
 ```

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -62,18 +62,16 @@ final class ProductResource extends Resource
 }
 ```
 
-Use the QueryBuilder and Response in your controller:
+Use the QueryBuilder in your controller:
 
 ```php
 final class ListController
 {
-    public function __invoke(Request $request, Response $response): JsonResponse
+    public function __invoke(Request $request)
     {
-        $products = QueryBuilder::for(Product::class, $request)
+        return QueryBuilder::for(Product::class, $request)
             ->fromResource(ProductResource::class)
             ->paginate();
-
-        return $response->success($products, ProductResource::class)->respond();
     }
 }
 ```

--- a/docs/query-builder/overview.mdx
+++ b/docs/query-builder/overview.mdx
@@ -3,7 +3,7 @@ title: Overview
 description: Fluent query builder that ties everything together
 ---
 
-The `QueryBuilder` is a fluent wrapper that applies filtering, sorting, includes, and pagination from the request. It reads defaults from your [Resource](/resources/overview) and allowing overrides.
+The `QueryBuilder` is a fluent wrapper that applies filtering, sorting, includes, and pagination from the request. It reads defaults from your [Resource](/resources/overview) and allows overrides.
 
 ## Why use it?
 
@@ -18,13 +18,14 @@ $query = Product::query();
 (new IncludeParser(allowed: [...]))->apply($request, $query);
 
 $results = (new OffsetPaginator())->paginate($request, $query);
+
+return $response->success($results, ProductResource::class)->respond();
 ```
 
 With the QueryBuilder:
 
 ```php
-// With QueryBuilder
-$results = QueryBuilder::for(Product::class, $request)
+return QueryBuilder::for(Product::class, $request)
     ->fromResource(ProductResource::class)
     ->paginate();
 ```
@@ -34,14 +35,14 @@ $results = QueryBuilder::for(Product::class, $request)
 ```php
 use Eufaturo\ApiToolkit\QueryBuilder;
 
-$products = QueryBuilder::for(Product::class, $request)
+return QueryBuilder::for(Product::class, $request)
     ->fromResource(ProductResource::class)
     ->paginate();
-
-return $response->success($products, ProductResource::class)->respond();
 ```
 
 The QueryBuilder reads `allowedFilters()`, `allowedSorts()`, `defaultSort()`, and `allowedIncludes()` from the Resource and applies them automatically.
+
+The terminal methods (`paginate()`, `cursorPaginate()`, `get()`) return a `SuccessResponse` that implements Laravel's `Responsable` interface. You can return it directly from controllers without calling `->respond()`.
 
 ## Starting from an existing query
 
@@ -50,7 +51,7 @@ You can pass an existing `Builder` instance instead of a model class:
 ```php
 $query = Product::query()->where('company_id', $companyId);
 
-$products = QueryBuilder::for($query, $request)
+return QueryBuilder::for($query, $request)
     ->fromResource(ProductResource::class)
     ->paginate();
 ```
@@ -59,21 +60,31 @@ $products = QueryBuilder::for($query, $request)
 
 | Method | Returns | Description |
 |--------|---------|-------------|
-| `paginate()` | `LengthAwarePaginator` | Offset-based pagination |
-| `cursorPaginate()` | `CursorPaginator` | Cursor-based pagination |
-| `get()` | `Collection` | All results (no pagination) |
+| `paginate()` | `SuccessResponse` | Offset-based pagination |
+| `cursorPaginate()` | `SuccessResponse` | Cursor-based pagination |
+| `get()` | `SuccessResponse` | All results (no pagination) |
+
+All terminal methods return a `SuccessResponse` which is `Responsable`. You can chain `->meta()` or `->links()` before returning:
+
+```php
+return QueryBuilder::for(Product::class, $request)
+    ->fromResource(ProductResource::class)
+    ->paginate()
+    ->meta(['request_id' => $requestId]);
+```
 
 ## Accessing the underlying query
 
-Use `getQuery()` to access the Eloquent `Builder` before executing:
+Use `apply()` + `getQuery()` when you need direct access to the Eloquent Builder:
 
 ```php
 $builder = QueryBuilder::for(Product::class, $request)
-    ->fromResource(ProductResource::class);
+    ->fromResource(ProductResource::class)
+    ->apply();
 
 $query = $builder->getQuery();
-// Add custom logic
 $query->whereHas('inventory', fn ($q) => $q->where('quantity', '>', 0));
 
-$products = $builder->paginate();
+// Use Response class directly when working with raw queries
+return $response->success($query->paginate(20), ProductResource::class);
 ```

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -65,20 +65,16 @@ final class ProductResource extends Resource
 ```php app/Http/Controllers/Products/ListController.php
 use App\Http\Resources\ProductResource;
 use App\Models\Product;
-use Eufaturo\ApiToolkit\Http\Response;
 use Eufaturo\ApiToolkit\QueryBuilder;
-use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 final class ListController
 {
-    public function __invoke(Request $request, Response $response): JsonResponse
+    public function __invoke(Request $request)
     {
-        $products = QueryBuilder::for(Product::class, $request)
+        return QueryBuilder::for(Product::class, $request)
             ->fromResource(ProductResource::class)
             ->paginate();
-
-        return $response->success($products, ProductResource::class)->respond();
     }
 }
 ```
@@ -89,13 +85,12 @@ final class ListController
 use App\Http\Resources\ProductResource;
 use App\Models\Product;
 use Eufaturo\ApiToolkit\Http\Response;
-use Illuminate\Http\JsonResponse;
 
 final class ViewController
 {
-    public function __invoke(Product $product, Response $response): JsonResponse
+    public function __invoke(Product $product, Response $response)
     {
-        return $response->success($product, ProductResource::class)->respond();
+        return $response->success($product, ProductResource::class);
     }
 }
 ```

--- a/docs/resources/collections.mdx
+++ b/docs/resources/collections.mdx
@@ -14,7 +14,7 @@ When you pass an array, `Collection`, or paginator to a success response, the to
 ```php
 $products = Product::query()->paginate(20);
 
-return $response->success($products, ProductResource::class)->respond();
+return $response->success($products, ProductResource::class);
 ```
 
 ## Supported data types

--- a/docs/resources/links-and-meta.mdx
+++ b/docs/resources/links-and-meta.mdx
@@ -101,8 +101,7 @@ In addition to resource-level links and meta, you can add response-level meta an
 return $response
     ->success($products, ProductResource::class)
     ->meta(['request_id' => $requestId])
-    ->links(['documentation' => 'https://docs.example.com/products'])
-    ->respond();
+    ->links(['documentation' => 'https://docs.example.com/products']);
 ```
 
 These are added to the top-level JSON:API document, separate from the individual resource objects.

--- a/docs/responses/error-responses.mdx
+++ b/docs/responses/error-responses.mdx
@@ -3,10 +3,12 @@ title: Error Responses
 description: Build JSON:API error responses
 ---
 
+`ErrorResponse` implements Laravel's `Responsable` interface. The HTTP status code is derived from the status you pass to `error()`, so you can return it directly without calling `->respond()`.
+
 ## Basic error
 
 ```php
-return $this->response->error('Not Found', 'Product does not exist', 404)->respond();
+return $this->response->error('Not Found', 'Product does not exist', 404);
 ```
 
 ```json
@@ -26,8 +28,7 @@ return $this->response->error('Not Found', 'Product does not exist', 404)->respo
 ```php
 return $this->response
     ->error('Validation Error', 'Name is required', 422)
-    ->code('validation_error')
-    ->respond();
+    ->code('validation_error');
 ```
 
 ```json
@@ -51,8 +52,7 @@ Point to the field that caused the error:
 return $this->response
     ->error('Validation Error', 'Name is required', 422)
     ->code('validation_error')
-    ->source(['pointer' => '/data/attributes/name'])
-    ->respond();
+    ->source(['pointer' => '/data/attributes/name']);
 ```
 
 ## With meta
@@ -60,13 +60,12 @@ return $this->response
 ```php
 return $this->response
     ->error('Rate Limited', 'Too many requests', 429)
-    ->meta(['retry_after' => 60])
-    ->respond();
+    ->meta(['retry_after' => 60]);
 ```
 
-## Custom status code on respond
+## Custom headers
 
-Override the status code at response time:
+Use `->respond()` when you need custom headers:
 
 ```php
 return $this->response

--- a/docs/responses/overview.mdx
+++ b/docs/responses/overview.mdx
@@ -20,6 +20,24 @@ final class ProductController
 }
 ```
 
+## Responsable
+
+Both `SuccessResponse` and `ErrorResponse` implement Laravel's `Responsable` interface. You can return them directly from controllers without calling `->respond()`:
+
+```php
+// No ->respond() needed
+return $this->response->success($product, ProductResource::class);
+
+// Also works with errors
+return $this->response->error('Not Found', 'Product does not exist', 404);
+```
+
+Use `->respond()` when you need a custom status code or headers:
+
+```php
+return $this->response->success($product, ProductResource::class)->respond(201);
+```
+
 ## Inject via constructor
 
 The `Response` class is registered as a singleton in the service container. Inject it via constructor dependency injection:

--- a/docs/responses/success-responses.mdx
+++ b/docs/responses/success-responses.mdx
@@ -3,10 +3,12 @@ title: Success Responses
 description: Build JSON:API success responses with data, meta, and links
 ---
 
+`SuccessResponse` implements Laravel's `Responsable` interface. You can return it directly from controllers without calling `->respond()`.
+
 ## Single resource
 
 ```php
-return $this->response->success($product, ProductResource::class)->respond();
+return $this->response->success($product, ProductResource::class);
 ```
 
 ```json
@@ -29,13 +31,25 @@ Pass an array, `Collection`, or paginator:
 ```php
 $products = Product::query()->paginate(20);
 
-return $this->response->success($products, ProductResource::class)->respond();
+return $this->response->success($products, ProductResource::class);
 ```
+
+## Via QueryBuilder
+
+The QueryBuilder returns a `SuccessResponse` directly from its terminal methods:
+
+```php
+return QueryBuilder::for(Product::class, $request)
+    ->fromResource(ProductResource::class)
+    ->paginate();
+```
+
+No need to call `$response->success()` or `->respond()`. The resource class is inherited from `fromResource()`.
 
 ## Null data
 
 ```php
-return $this->response->success()->respond();
+return $this->response->success();
 ```
 
 ```json
@@ -49,7 +63,7 @@ return $this->response->success()->respond();
 When you don't need a Resource transformation:
 
 ```php
-return $this->response->success(['message' => 'Import started'])->respond();
+return $this->response->success(['message' => 'Import started']);
 ```
 
 ```json
@@ -59,6 +73,8 @@ return $this->response->success(['message' => 'Import started'])->respond();
 ```
 
 ## Custom status code
+
+Use `->respond()` when you need a non-200 status code:
 
 ```php
 return $this->response
@@ -71,8 +87,7 @@ return $this->response
 ```php
 return $this->response
     ->success($products, ProductResource::class)
-    ->meta(['request_id' => $requestId])
-    ->respond();
+    ->meta(['request_id' => $requestId]);
 ```
 
 ```json
@@ -94,11 +109,12 @@ return $this->response
 ```php
 return $this->response
     ->success($product, ProductResource::class)
-    ->links(['self' => '/api/v1/products/abc-123'])
-    ->respond();
+    ->links(['self' => '/api/v1/products/abc-123']);
 ```
 
 ## Custom headers
+
+Use `->respond()` when you need custom headers:
 
 ```php
 return $this->response
@@ -108,7 +124,7 @@ return $this->response
 
 ## Getting the array representation
 
-Use `toArray()` instead of `respond()` to get the raw array without creating a `JsonResponse`:
+Use `toArray()` to get the raw array without creating a `JsonResponse`:
 
 ```php
 $data = $this->response

--- a/src/Http/ErrorResponse.php
+++ b/src/Http/ErrorResponse.php
@@ -6,7 +6,7 @@ namespace Eufaturo\ApiToolkit\Http;
 
 use Illuminate\Http\JsonResponse;
 
-final class ErrorResponse
+final class ErrorResponse implements \Illuminate\Contracts\Support\Responsable
 {
     /**
      * @var array<string, mixed>
@@ -52,6 +52,11 @@ final class ErrorResponse
         $this->source = $source;
 
         return $this;
+    }
+
+    public function toResponse($request): JsonResponse
+    {
+        return $this->respond();
     }
 
     public function respond(int | null $status = null, array $headers = []): JsonResponse

--- a/src/Http/SuccessResponse.php
+++ b/src/Http/SuccessResponse.php
@@ -13,7 +13,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 
-final class SuccessResponse
+final class SuccessResponse implements \Illuminate\Contracts\Support\Responsable
 {
     /**
      * @var array<string, mixed>
@@ -61,6 +61,11 @@ final class SuccessResponse
         $this->links = array_merge($this->links, $links);
 
         return $this;
+    }
+
+    public function toResponse($request): JsonResponse
+    {
+        return $this->respond();
     }
 
     public function respond(int $status = 200, array $headers = []): JsonResponse

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Eufaturo\ApiToolkit;
 
+use Eufaturo\ApiToolkit\Http\SuccessResponse;
 use Eufaturo\ApiToolkit\Pagination\CursorPaginator;
 use Eufaturo\ApiToolkit\Pagination\OffsetPaginator;
 use Eufaturo\ApiToolkit\Parsers\FilterParser;
@@ -12,10 +13,7 @@ use Eufaturo\ApiToolkit\Parsers\IncludeParser;
 use Eufaturo\ApiToolkit\Parsers\PageParser;
 use Eufaturo\ApiToolkit\Parsers\SortParser;
 use Eufaturo\ApiToolkit\Resources\Resource;
-use Illuminate\Contracts\Pagination\CursorPaginator as CursorPaginatorContract;
-use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 
@@ -101,29 +99,31 @@ final class QueryBuilder
         return $this;
     }
 
-    public function paginate(): LengthAwarePaginator
+    public function paginate(): SuccessResponse
     {
         $this->applyAll();
 
         $pageParser = app(PageParser::class);
+        $data = (new OffsetPaginator($pageParser))->paginate($this->request, $this->query);
 
-        return (new OffsetPaginator($pageParser))->paginate($this->request, $this->query);
+        return $this->toSuccessResponse($data);
     }
 
-    public function cursorPaginate(): CursorPaginatorContract
+    public function cursorPaginate(): SuccessResponse
     {
         $this->applyAll();
 
         $pageParser = app(PageParser::class);
+        $data = (new CursorPaginator($pageParser))->paginate($this->request, $this->query);
 
-        return (new CursorPaginator($pageParser))->paginate($this->request, $this->query);
+        return $this->toSuccessResponse($data);
     }
 
-    public function get(): Collection
+    public function get(): SuccessResponse
     {
         $this->applyAll();
 
-        return $this->query->get();
+        return $this->toSuccessResponse($this->query->get());
     }
 
     public function apply(): static
@@ -136,6 +136,18 @@ final class QueryBuilder
     public function getQuery(): Builder
     {
         return $this->query;
+    }
+
+    private function toSuccessResponse(mixed $data): SuccessResponse
+    {
+        $response = new SuccessResponse(
+            data: $data,
+            resource: $this->resourceClass,
+        );
+
+        $response->withRequest($this->request);
+
+        return $response;
     }
 
     private function applyAll(): void

--- a/tests/Acceptance/JsonApi/ListEndpointTest.php
+++ b/tests/Acceptance/JsonApi/ListEndpointTest.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 
 namespace Eufaturo\ApiToolkit\Tests\Acceptance\JsonApi;
 
-use Eufaturo\ApiToolkit\Http\Response;
 use Eufaturo\ApiToolkit\QueryBuilder;
 use Eufaturo\ApiToolkit\Tests\Fixtures\Models\Category;
 use Eufaturo\ApiToolkit\Tests\Fixtures\Models\Product;
@@ -21,13 +20,11 @@ final class ListEndpointTest extends TestCase
     {
         parent::setUp();
 
-        Route::get('/api/v1/products', function (Response $response) {
-            $products = QueryBuilder::for(Product::class, request())
+        Route::get('/api/v1/products', function () {
+            return QueryBuilder::for(Product::class, request())
                 ->fromResource(ProductResource::class)
                 ->paginate()
             ;
-
-            return $response->success($products, ProductResource::class)->respond();
         });
     }
 

--- a/tests/Fixtures/Models/Category.php
+++ b/tests/Fixtures/Models/Category.php
@@ -12,7 +12,7 @@ final class Category extends Model
     protected $guarded = [];
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\HasMany<\Eufaturo\ApiToolkit\Tests\Fixtures\Models\Product, $this>
+     * @return HasMany<Product, $this>
      */
     public function products(): HasMany
     {

--- a/tests/Fixtures/Models/Product.php
+++ b/tests/Fixtures/Models/Product.php
@@ -24,7 +24,7 @@ final class Product extends Model
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo<\Eufaturo\ApiToolkit\Tests\Fixtures\Models\Category, $this>
+     * @return BelongsTo<Category, $this>
      */
     public function category(): BelongsTo
     {
@@ -32,7 +32,7 @@ final class Product extends Model
     }
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<\Eufaturo\ApiToolkit\Tests\Fixtures\Models\Tag, $this, \Illuminate\Database\Eloquent\Relations\Pivot>
+     * @return BelongsToMany<Tag, $this, \Illuminate\Database\Eloquent\Relations\Pivot>
      */
     public function tags(): BelongsToMany
     {

--- a/tests/Fixtures/Models/Tag.php
+++ b/tests/Fixtures/Models/Tag.php
@@ -12,7 +12,7 @@ final class Tag extends Model
     protected $guarded = [];
 
     /**
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany<\Eufaturo\ApiToolkit\Tests\Fixtures\Models\Product, $this, \Illuminate\Database\Eloquent\Relations\Pivot>
+     * @return BelongsToMany<Product, $this, \Illuminate\Database\Eloquent\Relations\Pivot>
      */
     public function products(): BelongsToMany
     {


### PR DESCRIPTION
SuccessResponse and ErrorResponse now implement Laravel's Responsable interface, so they can be returned directly from controllers without calling ->respond().

QueryBuilder terminal methods (paginate, cursorPaginate, get) now return SuccessResponse instead of raw data, inheriting the resource class from fromResource(). This eliminates the need to repeat the resource class and call ->respond().

Before:
  $products = QueryBuilder::for(Product::class, $request)
      ->fromResource(ProductResource::class)
      ->paginate();
  return $response->success($products, ProductResource::class)->respond();

After:
  return QueryBuilder::for(Product::class, $request)
      ->fromResource(ProductResource::class)
      ->paginate();