### PR TITLE
Add global ID and type resolution callbacks

### DIFF
--- a/docs/resources/overview.mdx
+++ b/docs/resources/overview.mdx
@@ -114,9 +114,44 @@ final class LegacyProductResource extends Resource
 ### Type resolution order
 
 1. `$type` if explicitly set
-2. `$model` table name if set
-3. Runtime model's table name (for Eloquent models passed at runtime)
-4. Snake-cased class name as fallback
+2. Global type resolver (if registered)
+3. `$model` table name if set
+4. Runtime model's table name (for Eloquent models passed at runtime)
+5. Snake-cased class name as fallback
+
+### ID resolution order
+
+1. Global ID resolver (if registered)
+2. `$model->public_id` (for Eloquent models)
+3. `$model->getKey()` (for Eloquent models)
+4. `$model->id` or `$model->public_id` (for plain objects)
+
+## Global resolvers
+
+Register global callbacks to customize how IDs and types are derived across all resources. Useful for projects that use UUIDs, hashids, or custom naming conventions.
+
+Register in a service provider:
+
+```php
+use Eufaturo\ApiToolkit\Resources\Resource;
+use Illuminate\Support\Str;
+
+// Use UUID as the resource ID
+Resource::resolveIdUsing(fn ($model) => $model->uuid);
+
+// Use snake-cased class name as the type
+Resource::resolveTypeUsing(fn ($model) => Str::snake(class_basename($model)));
+```
+
+The callback receives the model and the current request:
+
+```php
+Resource::resolveIdUsing(function ($model, ?Request $request) {
+    return $model->uuid;
+});
+```
+
+Explicit `$type` on a resource always takes precedence over the global resolver. Reset both resolvers with `Resource::resetResolvers()`.
 
 ## Request access
 

--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Eufaturo\ApiToolkit\Resources;
 
 use BadMethodCallException;
+use Closure;
 use Eufaturo\ApiToolkit\Parsers\Filters\Filter;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
@@ -22,6 +23,12 @@ use Illuminate\Support\Str;
  */
 class Resource
 {
+    /** @var (Closure(mixed, Request|null): string)|null */
+    private static Closure | null $idResolver = null;
+
+    /** @var (Closure(mixed, Request|null): string)|null */
+    private static Closure | null $typeResolver = null;
+
     /**
      * The model class this resource represents.
      * When set to an Eloquent model, the JSON:API type is derived from its table name.
@@ -39,6 +46,35 @@ class Resource
      * The current request instance, available in all methods via $this->request.
      */
     protected Request | null $request = null;
+
+    /**
+     * Register a global callback to resolve the resource ID.
+     *
+     * @param Closure(mixed, Request|null): string $callback
+     */
+    public static function resolveIdUsing(Closure $callback): void
+    {
+        self::$idResolver = $callback;
+    }
+
+    /**
+     * Register a global callback to resolve the resource type.
+     *
+     * @param Closure(mixed, Request|null): string $callback
+     */
+    public static function resolveTypeUsing(Closure $callback): void
+    {
+        self::$typeResolver = $callback;
+    }
+
+    /**
+     * Reset global resolvers (useful for testing).
+     */
+    public static function resetResolvers(): void
+    {
+        self::$idResolver = null;
+        self::$typeResolver = null;
+    }
 
     public static function make(mixed ...$data): array | null
     {
@@ -153,6 +189,10 @@ class Resource
             return $this->type;
         }
 
+        if (self::$typeResolver !== null && $model !== null) {
+            return (self::$typeResolver)($model, $this->request);
+        }
+
         if ($this->model !== '') {
             return (new $this->model())->getTable();
         }
@@ -170,6 +210,10 @@ class Resource
 
     public function resolveId($model): string
     {
+        if (self::$idResolver !== null) {
+            return (self::$idResolver)($model, $this->request);
+        }
+
         if ($model instanceof Model) {
             return (string) ($model->public_id ?? $model->getKey());
         }

--- a/tests/Feature/Resources/ResourceTest.php
+++ b/tests/Feature/Resources/ResourceTest.php
@@ -234,4 +234,101 @@ final class ResourceTest extends TestCase
         $this->assertArrayNotHasKey('self', $result['links']);
         $this->assertSame('/related/1', $result['links']['related']);
     }
+
+    #[Test]
+    #[TestDox('it uses global ID resolver')]
+    public function it_uses_global_id_resolver(): void
+    {
+        Resource::resolveIdUsing(fn ($model) => 'custom-'.$model->id);
+
+        $resource = new class() extends Resource {
+            protected string $type = 'items';
+
+            public function attributes($model): array
+            {
+                return [];
+            }
+        };
+
+        $model = new stdClass();
+        $model->id = '42';
+
+        $result = $resource->toArray($model);
+
+        $this->assertSame('custom-42', $result['id']);
+
+        Resource::resetResolvers();
+    }
+
+    #[Test]
+    #[TestDox('it uses global type resolver')]
+    public function it_uses_global_type_resolver(): void
+    {
+        Resource::resolveTypeUsing(fn ($model) => 'custom-type');
+
+        $resource = new class() extends Resource {
+            public function attributes($model): array
+            {
+                return [];
+            }
+        };
+
+        $model = new stdClass();
+        $model->id = '1';
+
+        $result = $resource->toArray($model);
+
+        $this->assertSame('custom-type', $result['type']);
+
+        Resource::resetResolvers();
+    }
+
+    #[Test]
+    #[TestDox('explicit type property takes precedence over global resolver')]
+    public function explicit_type_takes_precedence(): void
+    {
+        Resource::resolveTypeUsing(fn ($model) => 'global-type');
+
+        $resource = new class() extends Resource {
+            protected string $type = 'explicit-type';
+
+            public function attributes($model): array
+            {
+                return [];
+            }
+        };
+
+        $model = new stdClass();
+        $model->id = '1';
+
+        $result = $resource->toArray($model);
+
+        $this->assertSame('explicit-type', $result['type']);
+
+        Resource::resetResolvers();
+    }
+
+    #[Test]
+    #[TestDox('reset resolvers restores default behavior')]
+    public function reset_resolvers_restores_defaults(): void
+    {
+        Resource::resolveIdUsing(fn ($model) => 'custom');
+        Resource::resetResolvers();
+
+        $resource = new class() extends Resource {
+            protected string $type = 'items';
+
+            public function attributes($model): array
+            {
+                return [];
+            }
+        };
+
+        $model = new stdClass();
+        $model->id = '99';
+
+        $result = $resource->toArray($model);
+
+        $this->assertSame('99', $result['id']);
+    }
 }


### PR DESCRIPTION
Register global callbacks via Resource::resolveIdUsing() and Resource::resolveTypeUsing() to customize how resource IDs and types are derived across all resources.

Useful for projects that use UUIDs, hashids, or custom type naming conventions. Register in a service provider:

  Resource::resolveIdUsing(fn ($model) => $model->uuid);
  Resource::resolveTypeUsing(fn ($model) => Str::snake(class_basename($model)));

Explicit $type property on a resource takes precedence over the global resolver. Resource::resetResolvers() clears both callbacks.