### PR TITLE
Add api-toolkit:make-resource artisan command

### DIFF
--- a/docs/resources/overview.mdx
+++ b/docs/resources/overview.mdx
@@ -46,6 +46,40 @@ This produces:
 }
 ```
 
+## Generating resources
+
+Use the artisan command to scaffold a new resource:
+
+```bash
+php artisan api-toolkit:make-resource ProductResource
+```
+
+This creates `app/Http/Resources/ProductResource.php` with the model auto-guessed from the name (`Product`):
+
+```php
+final class ProductResource extends Resource
+{
+    protected string $model = Product::class;
+
+    public function attributes(Product $product): array
+    {
+        return [
+            //
+        ];
+    }
+}
+```
+
+### Options
+
+```bash
+# Explicit model class
+php artisan api-toolkit:make-resource ProductResource --model=App\\Models\\Product
+
+# Plain resource without a model (uses $type instead of $model)
+php artisan api-toolkit:make-resource DateResource --plain
+```
+
 ## Key concepts
 
 <CardGroup cols={2}>

--- a/src/ApiToolkitServiceProvider.php
+++ b/src/ApiToolkitServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Eufaturo\ApiToolkit;
 
 use Eufaturo\ApiToolkit\Console\GenerateOpenApiCommand;
+use Eufaturo\ApiToolkit\Console\MakeResourceCommand;
 use Eufaturo\ApiToolkit\Http\Response;
 use Eufaturo\ApiToolkit\Parsers\PageParser;
 use Eufaturo\IdempotencyMiddleware\IdempotencyServiceProvider;
@@ -36,6 +37,7 @@ final class ApiToolkitServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->commands([
                 GenerateOpenApiCommand::class,
+                MakeResourceCommand::class,
             ]);
         }
 

--- a/src/Console/MakeResourceCommand.php
+++ b/src/Console/MakeResourceCommand.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Eufaturo\ApiToolkit\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+final class MakeResourceCommand extends Command
+{
+    protected $signature = 'api-toolkit:make-resource
+        {name : The name of the resource class (e.g. ProductResource)}
+        {--model= : The model class to associate with the resource}
+        {--plain : Create a resource without a model (uses $type instead of $model)}';
+
+    protected $description = 'Create a new API Toolkit resource class';
+
+    public function handle(): int
+    {
+        $name = $this->argument('name');
+        $modelOption = $this->option('model');
+        $plain = $this->option('plain');
+
+        $resourceClass = Str::studly($name);
+
+        if (! str_ends_with($resourceClass, 'Resource')) {
+            $resourceClass .= 'Resource';
+        }
+
+        $path = app_path('Http/Resources/'.$resourceClass.'.php');
+        $directory = dirname($path);
+
+        if (file_exists($path)) {
+            $this->error("Resource [{$resourceClass}] already exists.");
+
+            return self::FAILURE;
+        }
+
+        if (! is_dir($directory)) {
+            mkdir($directory, 0755, true);
+        }
+
+        if ($plain) {
+            $typeName = $this->deriveTypeName($resourceClass);
+            $content = $this->buildPlainStub($resourceClass, $typeName);
+        } else {
+            $modelClass = $modelOption ?? $this->guessModel($resourceClass);
+            $content = $this->buildModelStub($resourceClass, $modelClass);
+        }
+
+        file_put_contents($path, $content);
+
+        $this->info("Resource [{$resourceClass}] created successfully.");
+
+        return self::SUCCESS;
+    }
+
+    private function buildModelStub(string $resourceClass, string $modelClass): string
+    {
+        $modelBaseName = class_basename($modelClass);
+        $modelImport = str_starts_with($modelClass, 'App\\') ? $modelClass : 'App\\Models\\'.$modelClass;
+
+        return <<<PHP
+            <?php
+
+            declare(strict_types = 1);
+
+            namespace App\Http\Resources;
+
+            use Eufaturo\ApiToolkit\Resources\Resource;
+            use {$modelImport};
+
+            final class {$resourceClass} extends Resource
+            {
+                protected string \$model = {$modelBaseName}::class;
+
+                public function attributes({$modelBaseName} \${$this->variableName($modelBaseName)}): array
+                {
+                    return [
+                        //
+                    ];
+                }
+            }
+
+            PHP;
+    }
+
+    private function buildPlainStub(string $resourceClass, string $typeName): string
+    {
+        return <<<PHP
+            <?php
+
+            declare(strict_types = 1);
+
+            namespace App\Http\Resources;
+
+            use Eufaturo\ApiToolkit\Resources\Resource;
+
+            final class {$resourceClass} extends Resource
+            {
+                protected string \$type = '{$typeName}';
+
+                public function attributes(\$model): array
+                {
+                    return [
+                        //
+                    ];
+                }
+            }
+
+            PHP;
+    }
+
+    private function guessModel(string $resourceClass): string
+    {
+        $modelName = str_replace('Resource', '', $resourceClass);
+
+        return 'App\\Models\\'.$modelName;
+    }
+
+    private function deriveTypeName(string $resourceClass): string
+    {
+        $name = str_replace('Resource', '', $resourceClass);
+
+        return Str::snake($name, '-');
+    }
+
+    private function variableName(string $modelBaseName): string
+    {
+        return Str::camel($modelBaseName);
+    }
+}


### PR DESCRIPTION
Scaffolds a new API Toolkit resource class.

Usage:
  php artisan api-toolkit:make-resource ProductResource
  php artisan api-toolkit:make-resource ProductResource --model=App\Models\Product
  php artisan api-toolkit:make-resource DateResource --plain

- Auto-guesses model from resource name (ProductResource -> App\Models\Product)
- --model flag for explicit model class
- --plain flag for non-model resources (uses $type instead of $model)
- Generated files include proper type hints on attributes()
- Outputs to app/Http/Resources/