### PR TITLE
Add scoping methods to TestDataResponse

### DIFF
--- a/docs/testing/assertions.mdx
+++ b/docs/testing/assertions.mdx
@@ -16,6 +16,15 @@ $response->assertErrorDetailContains('product');
 $response->assertErrorCode('invalid_request_error');
 ```
 
+### Validation error assertions
+
+Assert a validation error exists for a specific field:
+
+```php
+$response->assertValidationError('name', 'Missing required field: name');
+$response->assertValidationError('billing.currency_id', 'The currency is invalid.');
+```
+
 ### Resource assertions
 
 ```php
@@ -23,22 +32,60 @@ $response->assertResourceType('products');
 $response->assertResourceId('abc-123');
 ```
 
-## TestDataResponse assertions
-
-These methods are available on the objects returned by `data()`, `errors()`, `included()`, and `meta()`:
-
-### Count
+### Shortcut helpers
 
 ```php
-$response->data()->assertCount(3);
+// Access data.attributes directly (single resource)
+$response->attributes()->assertSame('name', 'Widget');
+```
+
+## TestDataResponse
+
+The `TestDataResponse` is returned by `data()`, `errors()`, `included()`, `meta()`, and `attributes()`. It supports chainable assertions and scoping methods.
+
+### Scoping into items
+
+Use `item()` to scope into a specific item in a collection:
+
+```php
+$response->data()->item(0)->assertSame('type', 'products');
+$response->data()->item(1)->assertSame('type', 'products');
+```
+
+### Scoping into JSON:API sections
+
+Drill into `attributes`, `relationships`, `meta`, or `links` of a resource object:
+
+```php
+// Single resource
+$response->data()->attributes()->assertSame('name', 'Widget');
+$response->data()->relationships()->assertHasKey('category');
+$response->data()->meta()->assertSame('is_available', true);
+$links = $response->data()->links();
+$links->assertSame('self', '/api/v1/products/abc-123');
+$links->assertSame('inventory', '/api/v1/products/abc-123/inventory');
+
+// Collection items
+$response->data()->item(0)->attributes()->assertSame('name', 'Widget');
+$response->data()->item(0)->relationships()->assertHasKey('category');
+```
+
+### Assigning to variables
+
+For multiple assertions on the same scope, assign to a variable:
+
+```php
+$first = $response->data()->item(0)->attributes();
+$first->assertSame('name', 'Widget');
+$first->assertSame('code', 'W01');
+$first->assertTrue('featured');
 ```
 
 ### Value assertions
 
 ```php
 $response->data()->assertSame('type', 'products');
-$response->data()->assertSame('attributes.name', 'Widget');
-$response->data()->assertNotSame('attributes.name', 'Gadget');
+$response->data()->assertNotSame('type', 'categories');
 ```
 
 Dot notation is supported for nested keys.
@@ -46,16 +93,21 @@ Dot notation is supported for nested keys.
 ### Boolean assertions
 
 ```php
-$response->data()->assertSame('attributes.active', true);
-$response->data()->assertTrue('attributes.active');
-$response->data()->assertFalse('attributes.archived');
+$response->attributes()->assertTrue('is_active');
+$response->attributes()->assertFalse('is_archived');
 ```
 
 ### Null assertions
 
 ```php
-$response->data()->assertNull('attributes.deleted_at');
-$response->data()->assertNotNull('attributes.created_at');
+$response->attributes()->assertNull('deleted_at');
+$response->attributes()->assertNotNull('created_at');
+```
+
+### Count
+
+```php
+$response->data()->assertCount(3);
 ```
 
 ### Empty assertions
@@ -68,23 +120,13 @@ $response->data()->assertNotEmpty();
 ### Key existence
 
 ```php
-$response->data()->assertHasKey('attributes.name');
-$response->data()->assertMissingKey('attributes.secret');
+$response->attributes()->assertHasKey('name');
+$response->attributes()->assertMissingKey('secret');
 ```
 
-## Chaining
+## Full examples
 
-All assertions return `$this`, so they can be chained:
-
-```php
-$response->data()
-    ->assertCount(1)
-    ->assertSame('0.type', 'products')
-    ->assertSame('0.attributes.name', 'Widget')
-    ->assertNotNull('0.attributes.created_at');
-```
-
-## Full example
+### Creating a resource
 
 ```php
 public function test_it_creates_a_product(): void
@@ -96,23 +138,28 @@ public function test_it_creates_a_product(): void
 
     $response->assertStatus(201);
     $response->assertResourceType('products');
-    $response->data()
-        ->assertSame('attributes.name', 'Widget')
-        ->assertSame('attributes.code', 'W01')
-        ->assertNotNull('id');
+    $response->attributes()
+        ->assertSame('name', 'Widget')
+        ->assertSame('code', 'W01');
 }
+```
 
+### Validation errors
+
+```php
 public function test_it_validates_required_fields(): void
 {
     $response = $this->postJson('/api/products', []);
 
     $response->assertStatus(422);
-    $response->assertErrorCode('validation_error');
-    $response->errors()
-        ->assertNotEmpty()
-        ->assertSame('0.source.pointer', '/name');
+    $response->assertValidationError('name', 'Missing required field: name');
+    $response->assertValidationError('code', 'Missing required field: code');
 }
+```
 
+### Listing with pagination
+
+```php
 public function test_it_lists_with_pagination(): void
 {
     Product::factory()->count(50)->create();
@@ -121,9 +168,33 @@ public function test_it_lists_with_pagination(): void
 
     $response->assertStatus(200);
     $response->data()->assertCount(20);
+
+    $first = $response->data()->item(0)->attributes();
+    $first->assertSame('name', 'Widget');
+    $first->assertNotNull('created_at');
+
     $response->meta()
         ->assertSame('page.currentPage', 1)
         ->assertSame('page.total', 50)
         ->assertSame('page.perPage', 20);
+}
+```
+
+### Collection with relationships
+
+```php
+public function test_it_includes_relationships(): void
+{
+    $response = $this->getJson('/api/products?include=category');
+
+    $response->assertStatus(200);
+
+    $first = $response->data()->item(0);
+    $first->attributes()->assertSame('name', 'Widget');
+    $first->relationships()->assertHasKey('category');
+
+    $response->included()->item(0)
+        ->assertSame('type', 'categories')
+        ->attributes()->assertSame('name', 'Electronics');
 }
 ```

--- a/src/Testing/TestDataResponse.php
+++ b/src/Testing/TestDataResponse.php
@@ -77,6 +77,48 @@ readonly class TestDataResponse
         return $this;
     }
 
+    /**
+     * Scope to a specific item in the array by index.
+     */
+    public function item(int $index): self
+    {
+        Assert::assertArrayHasKey($index, $this->data, "Failed asserting that data has item at index [{$index}].");
+
+        return new self($this->data[$index]);
+    }
+
+    /**
+     * Scope to the attributes key of the current data.
+     */
+    public function attributes(): self
+    {
+        return new self($this->data['attributes'] ?? []);
+    }
+
+    /**
+     * Scope to the relationships key of the current data.
+     */
+    public function relationships(): self
+    {
+        return new self($this->data['relationships'] ?? []);
+    }
+
+    /**
+     * Scope to the meta key of the current data.
+     */
+    public function meta(): self
+    {
+        return new self($this->data['meta'] ?? []);
+    }
+
+    /**
+     * Scope to the links key of the current data.
+     */
+    public function links(): self
+    {
+        return new self($this->data['links'] ?? []);
+    }
+
     public function assertHasKey(string $key): self
     {
         Assert::assertTrue(Arr::has($this->data, $key), "Failed asserting that data has key [{$key}].");


### PR DESCRIPTION
Add item(), attributes(), relationships(), meta(), and links() methods for drilling into nested JSON:API structures in tests.

Before:
  $response->data()->assertSame('0.attributes.name', 'Widget');

After:
  $response->data()->item(0)->attributes()->assertSame('name', 'Widget');