### PR TITLE
Extract CreatesTestResponse trait for Pest compatibility

### DIFF
--- a/src/Testing/CreatesTestResponse.php
+++ b/src/Testing/CreatesTestResponse.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace BlueBeetle\ApiToolkit\Testing;
+
+use Illuminate\Testing\LoggedExceptionCollection;
+
+trait CreatesTestResponse
+{
+    protected function createTestResponse($response, $request): TestResponse
+    {
+        return tap(TestResponse::fromBaseResponse($response, $request), function ($response) {
+            $response->withExceptions(
+                $this->app->bound(LoggedExceptionCollection::class)
+                    ? $this->app->make(LoggedExceptionCollection::class)
+                    : new LoggedExceptionCollection(),
+            );
+        });
+    }
+}

--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -4,18 +4,7 @@ declare(strict_types = 1);
 
 namespace BlueBeetle\ApiToolkit\Testing;
 
-use Illuminate\Testing\LoggedExceptionCollection;
-
 abstract class TestCase extends \Illuminate\Foundation\Testing\TestCase
 {
-    protected function createTestResponse($response, $request): TestResponse
-    {
-        return tap(TestResponse::fromBaseResponse($response, $request), function ($response) {
-            $response->withExceptions(
-                $this->app->bound(LoggedExceptionCollection::class)
-                    ? $this->app->make(LoggedExceptionCollection::class)
-                    : new LoggedExceptionCollection(),
-            );
-        });
-    }
+    use CreatesTestResponse;
 }


### PR DESCRIPTION
Move createTestResponse override into a reusable trait so Pest users can mix it into their own TestCase without extending ours.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bluebeetlept/codesmith/api-toolkit/pr/16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->