### PR TITLE
Convert PHPUnit tests to Pest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,8 @@ jobs:
         php: ["8.4"]
 
         actions:
-          - name: Execute PHPUnit
-            run: ./vendor/bin/phpunit -c phpunit.ci.dist.xml
+          - name: Execute Pest
+            run: ./vendor/bin/pest -c phpunit.ci.dist.xml
 
     name: PHP ${{ matrix.php }}
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "eufaturo/coding-standards": "dev-main",
         "mockery/mockery": "^1.6",
         "orchestra/testbench": "^11.0",
-        "phpunit/phpunit": "^13.0"
+        "pestphp/pest": "^4.6.3"
     },
     "autoload": {
         "psr-4": {
@@ -37,10 +37,10 @@
         }
     },
     "scripts": {
-        "test": "./vendor/bin/phpunit -c phpunit.dist.xml",
+        "test": "./vendor/bin/pest -c phpunit.dist.xml",
         "test:coverage": [
             "@putenv XDEBUG_MODE=coverage",
-            "./vendor/bin/phpunit -c phpunit-coverage.dist.xml"
+            "./vendor/bin/pest -c phpunit-coverage.dist.xml"
         ],
         "ecs:fix": "./vendor/bin/ecs --fix",
         "ecs:check": "./vendor/bin/ecs",
@@ -55,7 +55,8 @@
         "sort-packages": true,
         "allow-plugins": {
             "php-http/discovery": true,
-            "eufaturo/coding-standards": true
+            "eufaturo/coding-standards": true,
+            "pestphp/pest-plugin": true
         }
     },
     "extra": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,5 +11,4 @@ parameters:
     parallel:
         processTimeout: 300.0
 
-    ignoreErrors:
-        - '#Dynamic call to static method PHPUnit\\Framework\\.*#'
+    ignoreErrors: []

--- a/tests/Acceptance/ExceptionHandlerTest.php
+++ b/tests/Acceptance/ExceptionHandlerTest.php
@@ -7,7 +7,6 @@ namespace BlueBeetle\ApiToolkit\Tests\Acceptance;
 use BlueBeetle\ApiToolkit\Exceptions\ConfigureExceptionHandler;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Exceptions\StubDomainException;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\Product;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
 use BlueBeetle\IdempotencyMiddleware\IdempotencyException;
 use Exception;
 use Illuminate\Auth\AuthenticationException;
@@ -16,340 +15,274 @@ use Illuminate\Database\LazyLoadingViolationException;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Validation\ValidationException;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
 use RuntimeException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Exception\RouteNotFoundException;
 
-final class ExceptionHandlerTest extends TestCase
-{
-    protected function resolveApplicationExceptionHandler($app): void
-    {
-        (new ConfigureExceptionHandler())($app);
-    }
+/** @var \BlueBeetle\ApiToolkit\Tests\TestCase $this */
+beforeEach(function () {
+    (new ConfigureExceptionHandler())($this->app);
+});
 
-    #[Test]
-    #[TestDox('it renders authentication exception as JSON:API error')]
-    public function it_renders_authentication_exception(): void
-    {
-        Route::get('/test', fn () => throw new AuthenticationException('Unauthenticated'));
+it('renders authentication exception as JSON:API error', function () {
+    Route::get('/test', fn () => throw new AuthenticationException('Unauthenticated'));
 
-        $response = $this->get('/test');
+    $response = $this->get('/test');
 
-        $response->assertStatus(Response::HTTP_UNAUTHORIZED);
-        $response->assertJsonPath('errors.0.status', '401');
-        $response->assertJsonPath('errors.0.code', 'invalid_request_error');
-        $response->assertJsonPath('errors.0.title', 'Unauthorized');
-    }
+    $response->assertStatus(Response::HTTP_UNAUTHORIZED);
+    $response->assertJsonPath('errors.0.status', '401');
+    $response->assertJsonPath('errors.0.code', 'invalid_request_error');
+    $response->assertJsonPath('errors.0.title', 'Unauthorized');
+});
 
-    #[Test]
-    #[TestDox('it renders validation exception as JSON:API errors')]
-    public function it_renders_validation_exception(): void
-    {
-        Route::post('/test', function () {
-            $validator = \Illuminate\Support\Facades\Validator::make([], [
+it('renders validation exception as JSON:API errors', function () {
+    Route::post('/test', function () {
+        $validator = \Illuminate\Support\Facades\Validator::make([], [
+            'name' => ['required'],
+            'email' => ['required', 'email'],
+        ]);
+
+        throw new ValidationException($validator);
+    });
+
+    $response = $this->postJson('/test');
+
+    $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+    $response->assertJsonPath('errors.0.code', 'validation_error');
+    $response->assertJsonPath('errors.0.source.pointer', '/name');
+    $response->assertJsonPath('errors.1.source.pointer', '/email');
+});
+
+it('renders not found for missing routes', function () {
+    $response = $this->get('/nonexistent');
+
+    $response->assertStatus(Response::HTTP_NOT_FOUND);
+    $response->assertJsonPath('errors.0.code', 'invalid_request_error');
+    $response->assertJsonPath('errors.0.title', 'Not Found');
+});
+
+it('renders method not allowed as not found', function () {
+    Route::get('/test', fn () => 'ok');
+
+    $response = $this->post('/test');
+
+    $response->assertStatus(Response::HTTP_NOT_FOUND);
+    $response->assertJsonPath('errors.0.code', 'invalid_request_error');
+});
+
+it('renders http exceptions', function () {
+    Route::get('/test', fn () => throw new HttpException(
+        statusCode: Response::HTTP_FORBIDDEN,
+        message: 'Access denied',
+    ));
+
+    $response = $this->get('/test');
+
+    $response->assertStatus(Response::HTTP_FORBIDDEN);
+    $response->assertJsonPath('errors.0.status', '403');
+    $response->assertJsonPath('errors.0.detail', 'Access denied');
+});
+
+it('renders generic exceptions as 500', function () {
+    Route::get('/test', fn () => throw new RuntimeException('Something broke'));
+
+    $response = $this->get('/test');
+
+    $response->assertStatus(Response::HTTP_INTERNAL_SERVER_ERROR);
+    $response->assertJsonPath('errors.0.code', 'api_error');
+});
+
+it('includes debug payload when debug is enabled', function () {
+    $this->app['config']->set('app.debug', true);
+
+    Route::get('/test', fn () => throw new HttpException(
+        statusCode: Response::HTTP_BAD_REQUEST,
+        message: 'Bad request',
+    ));
+
+    $response = $this->get('/test');
+
+    $response->assertStatus(Response::HTTP_BAD_REQUEST);
+    $response->assertJsonStructure([
+        'errors' => [
+            ['status', 'code', 'title', 'detail', 'meta' => ['debug' => ['line', 'file', 'class', 'trace']]],
+        ],
+    ]);
+});
+
+it('excludes debug payload when debug is disabled', function () {
+    $this->app['config']->set('app.debug', false);
+
+    Route::get('/test', fn () => throw new HttpException(
+        statusCode: Response::HTTP_BAD_REQUEST,
+        message: 'Bad request',
+    ));
+
+    $response = $this->get('/test');
+
+    $response->assertStatus(Response::HTTP_BAD_REQUEST);
+    $response->assertJsonMissingPath('errors.0.meta');
+});
+
+it('renders query exception as 400', function () {
+    $this->app['config']->set('app.debug', false);
+
+    Route::get('/test', fn () => throw new QueryException(
+        connectionName: 'testing',
+        sql: 'SELECT * FROM invalid_table',
+        bindings: [],
+        previous: new Exception('Table not found'),
+    ));
+
+    $response = $this->get('/test');
+
+    $response->assertStatus(Response::HTTP_BAD_REQUEST);
+    $response->assertJsonPath('errors.0.code', 'invalid_request_error');
+    $response->assertJsonPath('errors.0.detail', 'There was a problem during a database query');
+});
+
+it('renders query exception with detail when debug is on', function () {
+    $this->app['config']->set('app.debug', true);
+
+    Route::get('/test', fn () => throw new QueryException(
+        connectionName: 'testing',
+        sql: 'SELECT * FROM invalid_table',
+        bindings: [],
+        previous: new Exception('Table not found'),
+    ));
+
+    $response = $this->get('/test');
+
+    $response->assertStatus(Response::HTTP_BAD_REQUEST);
+    $response->assertJsonPath('errors.0.code', 'invalid_request_error');
+    expect($response->json('errors.0.detail'))->not->toBe('There was a problem during a database query');
+});
+
+it('renders lazy loading violation as 400', function () {
+    $this->app['config']->set('app.debug', false);
+
+    Route::get('/test', fn () => throw new LazyLoadingViolationException(
+        model: new Product(),
+        relation: 'category',
+    ));
+
+    $response = $this->get('/test');
+
+    $response->assertStatus(Response::HTTP_BAD_REQUEST);
+    $response->assertJsonPath('errors.0.code', 'invalid_request_error');
+    $response->assertJsonPath('errors.0.detail', 'There was a problem during a database query');
+});
+
+it('renders model not found exception', function () {
+    $modelException = (new ModelNotFoundException())->setModel(Product::class, ['abc-123']);
+
+    Route::get('/test', fn () => throw new NotFoundHttpException(
+        message: '',
+        previous: $modelException,
+    ));
+
+    $response = $this->get('/test');
+
+    $response->assertStatus(Response::HTTP_NOT_FOUND);
+    $response->assertJsonPath('errors.0.code', 'invalid_request_error');
+    $response->assertJsonPath('errors.0.title', 'Not Found');
+    expect($response->json('errors.0.detail'))->toContain('product');
+    expect($response->json('errors.0.detail'))->toContain('abc-123');
+});
+
+it('renders idempotency exception', function () {
+    Route::post('/test', fn () => throw new IdempotencyException('Request already processed'));
+
+    $response = $this->postJson('/test');
+
+    $response->assertStatus(Response::HTTP_BAD_REQUEST);
+    $response->assertJsonPath('errors.0.code', 'idempotency_error');
+    $response->assertJsonPath('errors.0.title', 'Idempotency Error');
+    $response->assertJsonPath('errors.0.detail', 'Request already processed');
+});
+
+it('renders route not found exception', function () {
+    Route::get('/test', fn () => throw new RouteNotFoundException(
+        'Route [api.products.index] not defined.',
+    ));
+
+    $response = $this->get('/test');
+
+    $response->assertStatus(Response::HTTP_NOT_FOUND);
+    $response->assertJsonPath('errors.0.code', 'invalid_request_error');
+    $response->assertJsonPath('errors.0.title', 'Not Found');
+    expect($response->json('errors.0.detail'))->toContain('api.products.index');
+});
+
+it('renders domain exceptions as 400', function () {
+    $this->app['config']->set('api-toolkit.exceptions.domain', [
+        StubDomainException::class,
+    ]);
+
+    Route::get('/test', fn () => throw new StubDomainException('Insufficient stock'));
+
+    $response = $this->get('/test');
+
+    $response->assertStatus(Response::HTTP_BAD_REQUEST);
+    $response->assertJsonPath('errors.0.code', 'invalid_request_error');
+    $response->assertJsonPath('errors.0.title', 'Bad Request');
+    $response->assertJsonPath('errors.0.detail', 'Insufficient stock');
+});
+
+it('respects dont_report config', function () {
+    $this->app['config']->set('api-toolkit.exceptions.dont_report', [
+        RuntimeException::class,
+    ]);
+
+    Route::get('/test', fn () => throw new RuntimeException('Should not be reported'));
+
+    $response = $this->get('/test');
+
+    $response->assertStatus(Response::HTTP_INTERNAL_SERVER_ERROR);
+});
+
+it('renders not found for root path', function () {
+    $response = $this->get('/');
+
+    $response->assertStatus(Response::HTTP_NOT_FOUND);
+    expect($response->json('errors.0.detail'))->toContain('GET: /');
+});
+
+it('sets json api content type on error responses', function () {
+    Route::get('/test', fn () => throw new RuntimeException('Error'));
+
+    $response = $this->get('/test');
+
+    $response->assertHeader('Content-Type', 'application/vnd.api+json');
+});
+
+it('renders multiple validation errors with source pointers', function () {
+    Route::post('/test', function () {
+        $validator = \Illuminate\Support\Facades\Validator::make(
+            ['email' => 'not-an-email'],
+            [
                 'name' => ['required'],
                 'email' => ['required', 'email'],
-            ]);
-
-            throw new ValidationException($validator);
-        });
-
-        $response = $this->postJson('/test');
-
-        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
-        $response->assertJsonPath('errors.0.code', 'validation_error');
-        $response->assertJsonPath('errors.0.source.pointer', '/name');
-        $response->assertJsonPath('errors.1.source.pointer', '/email');
-    }
-
-    #[Test]
-    #[TestDox('it renders not found for missing routes')]
-    public function it_renders_not_found(): void
-    {
-        $response = $this->get('/nonexistent');
-
-        $response->assertStatus(Response::HTTP_NOT_FOUND);
-        $response->assertJsonPath('errors.0.code', 'invalid_request_error');
-        $response->assertJsonPath('errors.0.title', 'Not Found');
-    }
-
-    #[Test]
-    #[TestDox('it renders method not allowed as not found')]
-    public function it_renders_method_not_allowed(): void
-    {
-        Route::get('/test', fn () => 'ok');
-
-        $response = $this->post('/test');
-
-        $response->assertStatus(Response::HTTP_NOT_FOUND);
-        $response->assertJsonPath('errors.0.code', 'invalid_request_error');
-    }
-
-    #[Test]
-    #[TestDox('it renders http exceptions')]
-    public function it_renders_http_exceptions(): void
-    {
-        Route::get('/test', fn () => throw new HttpException(
-            statusCode: Response::HTTP_FORBIDDEN,
-            message: 'Access denied',
-        ));
-
-        $response = $this->get('/test');
-
-        $response->assertStatus(Response::HTTP_FORBIDDEN);
-        $response->assertJsonPath('errors.0.status', '403');
-        $response->assertJsonPath('errors.0.detail', 'Access denied');
-    }
-
-    #[Test]
-    #[TestDox('it renders generic exceptions as 500')]
-    public function it_renders_generic_exceptions(): void
-    {
-        Route::get('/test', fn () => throw new RuntimeException('Something broke'));
-
-        $response = $this->get('/test');
-
-        $response->assertStatus(Response::HTTP_INTERNAL_SERVER_ERROR);
-        $response->assertJsonPath('errors.0.code', 'api_error');
-    }
-
-    #[Test]
-    #[TestDox('it includes debug payload when debug is enabled')]
-    public function it_includes_debug_when_enabled(): void
-    {
-        $this->app['config']->set('app.debug', true);
-
-        Route::get('/test', fn () => throw new HttpException(
-            statusCode: Response::HTTP_BAD_REQUEST,
-            message: 'Bad request',
-        ));
-
-        $response = $this->get('/test');
-
-        $response->assertStatus(Response::HTTP_BAD_REQUEST);
-        $response->assertJsonStructure([
-            'errors' => [
-                ['status', 'code', 'title', 'detail', 'meta' => ['debug' => ['line', 'file', 'class', 'trace']]],
+                'age' => ['required', 'integer'],
             ],
-        ]);
+        );
+
+        throw new ValidationException($validator);
+    });
+
+    $response = $this->postJson('/test');
+
+    $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+
+    $errors = $response->json('errors');
+
+    expect(count($errors))->toBeGreaterThanOrEqual(3);
+
+    foreach ($errors as $error) {
+        expect($error['code'])->toBe('validation_error');
+        expect($error['title'])->toBe('Validation Error');
+        expect($error['source'])->toHaveKey('pointer');
     }
-
-    #[Test]
-    #[TestDox('it excludes debug payload when debug is disabled')]
-    public function it_excludes_debug_when_disabled(): void
-    {
-        $this->app['config']->set('app.debug', false);
-
-        Route::get('/test', fn () => throw new HttpException(
-            statusCode: Response::HTTP_BAD_REQUEST,
-            message: 'Bad request',
-        ));
-
-        $response = $this->get('/test');
-
-        $response->assertStatus(Response::HTTP_BAD_REQUEST);
-        $response->assertJsonMissingPath('errors.0.meta');
-    }
-
-    #[Test]
-    #[TestDox('it renders query exception as 400')]
-    public function it_renders_query_exception(): void
-    {
-        $this->app['config']->set('app.debug', false);
-
-        Route::get('/test', fn () => throw new QueryException(
-            connectionName: 'testing',
-            sql: 'SELECT * FROM invalid_table',
-            bindings: [],
-            previous: new Exception('Table not found'),
-        ));
-
-        $response = $this->get('/test');
-
-        $response->assertStatus(Response::HTTP_BAD_REQUEST);
-        $response->assertJsonPath('errors.0.code', 'invalid_request_error');
-        $response->assertJsonPath('errors.0.detail', 'There was a problem during a database query');
-    }
-
-    #[Test]
-    #[TestDox('it renders query exception with detail when debug is on')]
-    public function it_renders_query_exception_with_debug(): void
-    {
-        $this->app['config']->set('app.debug', true);
-
-        Route::get('/test', fn () => throw new QueryException(
-            connectionName: 'testing',
-            sql: 'SELECT * FROM invalid_table',
-            bindings: [],
-            previous: new Exception('Table not found'),
-        ));
-
-        $response = $this->get('/test');
-
-        $response->assertStatus(Response::HTTP_BAD_REQUEST);
-        $response->assertJsonPath('errors.0.code', 'invalid_request_error');
-        // When debug is on, the actual exception message is shown
-        $this->assertNotSame('There was a problem during a database query', $response->json('errors.0.detail'));
-    }
-
-    #[Test]
-    #[TestDox('it renders lazy loading violation as 400')]
-    public function it_renders_lazy_loading_violation(): void
-    {
-        $this->app['config']->set('app.debug', false);
-
-        Route::get('/test', fn () => throw new LazyLoadingViolationException(
-            model: new Product(),
-            relation: 'category',
-        ));
-
-        $response = $this->get('/test');
-
-        $response->assertStatus(Response::HTTP_BAD_REQUEST);
-        $response->assertJsonPath('errors.0.code', 'invalid_request_error');
-        $response->assertJsonPath('errors.0.detail', 'There was a problem during a database query');
-    }
-
-    #[Test]
-    #[TestDox('it renders model not found exception')]
-    public function it_renders_model_not_found(): void
-    {
-        $modelException = (new ModelNotFoundException())->setModel(Product::class, ['abc-123']);
-
-        Route::get('/test', fn () => throw new NotFoundHttpException(
-            message: '',
-            previous: $modelException,
-        ));
-
-        $response = $this->get('/test');
-
-        $response->assertStatus(Response::HTTP_NOT_FOUND);
-        $response->assertJsonPath('errors.0.code', 'invalid_request_error');
-        $response->assertJsonPath('errors.0.title', 'Not Found');
-        $this->assertStringContainsString('product', $response->json('errors.0.detail'));
-        $this->assertStringContainsString('abc-123', $response->json('errors.0.detail'));
-    }
-
-    #[Test]
-    #[TestDox('it renders idempotency exception')]
-    public function it_renders_idempotency_exception(): void
-    {
-        Route::post('/test', fn () => throw new IdempotencyException('Request already processed'));
-
-        $response = $this->postJson('/test');
-
-        $response->assertStatus(Response::HTTP_BAD_REQUEST);
-        $response->assertJsonPath('errors.0.code', 'idempotency_error');
-        $response->assertJsonPath('errors.0.title', 'Idempotency Error');
-        $response->assertJsonPath('errors.0.detail', 'Request already processed');
-    }
-
-    #[Test]
-    #[TestDox('it renders route not found exception')]
-    public function it_renders_route_not_found(): void
-    {
-        Route::get('/test', fn () => throw new RouteNotFoundException(
-            'Route [api.products.index] not defined.',
-        ));
-
-        $response = $this->get('/test');
-
-        $response->assertStatus(Response::HTTP_NOT_FOUND);
-        $response->assertJsonPath('errors.0.code', 'invalid_request_error');
-        $response->assertJsonPath('errors.0.title', 'Not Found');
-        $this->assertStringContainsString('api.products.index', $response->json('errors.0.detail'));
-    }
-
-    #[Test]
-    #[TestDox('it renders domain exceptions as 400')]
-    public function it_renders_domain_exceptions(): void
-    {
-        $this->app['config']->set('api-toolkit.exceptions.domain', [
-            StubDomainException::class,
-        ]);
-
-        Route::get('/test', fn () => throw new StubDomainException('Insufficient stock'));
-
-        $response = $this->get('/test');
-
-        $response->assertStatus(Response::HTTP_BAD_REQUEST);
-        $response->assertJsonPath('errors.0.code', 'invalid_request_error');
-        $response->assertJsonPath('errors.0.title', 'Bad Request');
-        $response->assertJsonPath('errors.0.detail', 'Insufficient stock');
-    }
-
-    #[Test]
-    #[TestDox('it respects dont_report config')]
-    public function it_respects_dont_report_config(): void
-    {
-        $this->app['config']->set('api-toolkit.exceptions.dont_report', [
-            RuntimeException::class,
-        ]);
-
-        Route::get('/test', fn () => throw new RuntimeException('Should not be reported'));
-
-        $response = $this->get('/test');
-
-        // Still renders the response, but the exception should not be reported
-        $response->assertStatus(Response::HTTP_INTERNAL_SERVER_ERROR);
-    }
-
-    #[Test]
-    #[TestDox('it renders not found for root path')]
-    public function it_renders_not_found_for_root_path(): void
-    {
-        $response = $this->get('/');
-
-        $response->assertStatus(Response::HTTP_NOT_FOUND);
-        $this->assertStringContainsString('GET: /', $response->json('errors.0.detail'));
-    }
-
-    #[Test]
-    #[TestDox('it sets json api content type on error responses')]
-    public function it_sets_content_type(): void
-    {
-        Route::get('/test', fn () => throw new RuntimeException('Error'));
-
-        $response = $this->get('/test');
-
-        $response->assertHeader('Content-Type', 'application/vnd.api+json');
-    }
-
-    #[Test]
-    #[TestDox('it renders multiple validation errors with source pointers')]
-    public function it_renders_multiple_validation_errors(): void
-    {
-        Route::post('/test', function () {
-            $validator = \Illuminate\Support\Facades\Validator::make(
-                ['email' => 'not-an-email'],
-                [
-                    'name' => ['required'],
-                    'email' => ['required', 'email'],
-                    'age' => ['required', 'integer'],
-                ],
-            );
-
-            throw new ValidationException($validator);
-        });
-
-        $response = $this->postJson('/test');
-
-        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
-
-        $errors = $response->json('errors');
-
-        // name required + email invalid + age required = 3 errors
-        $this->assertGreaterThanOrEqual(3, count($errors));
-
-        // All errors should have validation_error code
-        foreach ($errors as $error) {
-            $this->assertSame('validation_error', $error['code']);
-            $this->assertSame('Validation Error', $error['title']);
-            $this->assertArrayHasKey('pointer', $error['source']);
-        }
-    }
-}
+});

--- a/tests/Acceptance/Http/Middleware/DetectLanguageTest.php
+++ b/tests/Acceptance/Http/Middleware/DetectLanguageTest.php
@@ -5,70 +5,55 @@ declare(strict_types = 1);
 namespace BlueBeetle\ApiToolkit\Tests\Acceptance\Http\Middleware;
 
 use BlueBeetle\ApiToolkit\Http\Middleware\DetectLanguage;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Http\Request;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
 use Symfony\Component\HttpFoundation\Response;
 
-final class DetectLanguageTest extends TestCase
-{
-    #[Test]
-    #[TestDox('it sets the locale from the Language header')]
-    public function it_sets_locale(): void
-    {
-        $middleware = $this->app->make(DetectLanguage::class);
+it('sets the locale from the Language header', function () {
+    $middleware = $this->app->make(DetectLanguage::class);
 
-        $this->app->make(Repository::class)->set('app.valid_locales', ['en', 'pt']);
+    $this->app->make(Repository::class)->set('app.valid_locales', ['en', 'pt']);
 
-        $request = Request::create('/');
-        $request->headers->set('Language', 'pt');
+    $request = Request::create('/');
+    $request->headers->set('Language', 'pt');
 
-        $middleware->handle(
-            request: $request,
-            next: fn (Request $request) => new Response('ok'),
-        );
+    $middleware->handle(
+        request: $request,
+        next: fn (Request $request) => new Response('ok'),
+    );
 
-        $this->assertSame('pt', $this->app->getLocale());
-    }
+    expect($this->app->getLocale())->toBe('pt');
+});
 
-    #[Test]
-    #[TestDox('it falls back to fallback locale for invalid language')]
-    public function it_falls_back(): void
-    {
-        $middleware = $this->app->make(DetectLanguage::class);
+it('falls back to fallback locale for invalid language', function () {
+    $middleware = $this->app->make(DetectLanguage::class);
 
-        $config = $this->app->make(Repository::class);
-        $config->set('app.valid_locales', ['en', 'pt']);
-        $config->set('app.fallback_locale', 'en');
+    $config = $this->app->make(Repository::class);
+    $config->set('app.valid_locales', ['en', 'pt']);
+    $config->set('app.fallback_locale', 'en');
 
-        $request = Request::create('/');
-        $request->headers->set('Language', 'invalid');
+    $request = Request::create('/');
+    $request->headers->set('Language', 'invalid');
 
-        $middleware->handle(
-            request: $request,
-            next: fn (Request $request) => new Response('ok'),
-        );
+    $middleware->handle(
+        request: $request,
+        next: fn (Request $request) => new Response('ok'),
+    );
 
-        $this->assertSame('en', $this->app->getLocale());
-    }
+    expect($this->app->getLocale())->toBe('en');
+});
 
-    #[Test]
-    #[TestDox('it does nothing without Language header')]
-    public function it_does_nothing_without_header(): void
-    {
-        $middleware = $this->app->make(DetectLanguage::class);
+it('does nothing without Language header', function () {
+    $middleware = $this->app->make(DetectLanguage::class);
 
-        $originalLocale = $this->app->getLocale();
+    $originalLocale = $this->app->getLocale();
 
-        $request = Request::create('/');
+    $request = Request::create('/');
 
-        $middleware->handle(
-            request: $request,
-            next: fn (Request $request) => new Response('ok'),
-        );
+    $middleware->handle(
+        request: $request,
+        next: fn (Request $request) => new Response('ok'),
+    );
 
-        $this->assertSame($originalLocale, $this->app->getLocale());
-    }
-}
+    expect($this->app->getLocale())->toBe($originalLocale);
+});

--- a/tests/Acceptance/Http/Middleware/ForceJsonApiResponseTest.php
+++ b/tests/Acceptance/Http/Middleware/ForceJsonApiResponseTest.php
@@ -5,28 +5,19 @@ declare(strict_types = 1);
 namespace BlueBeetle\ApiToolkit\Tests\Acceptance\Http\Middleware;
 
 use BlueBeetle\ApiToolkit\Http\Middleware\ForceJsonApiResponse;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
 use Illuminate\Http\Request;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
 use Symfony\Component\HttpFoundation\Response;
 
-final class ForceJsonApiResponseTest extends TestCase
-{
-    #[Test]
-    #[TestDox('it sets the content type to application/vnd.api+json')]
-    public function it_sets_content_type(): void
-    {
-        $middleware = $this->app->make(ForceJsonApiResponse::class);
+it('sets the content type to application/vnd.api+json', function () {
+    $middleware = $this->app->make(ForceJsonApiResponse::class);
 
-        $request = Request::create('/');
+    $request = Request::create('/');
 
-        $response = $middleware->handle(
-            request: $request,
-            next: fn (Request $request) => new Response('{"data": null}'),
-        );
+    $response = $middleware->handle(
+        request: $request,
+        next: fn (Request $request) => new Response('{"data": null}'),
+    );
 
-        $this->assertSame('application/vnd.api+json', $response->headers->get('Content-Type'));
-        $this->assertSame(200, $response->getStatusCode());
-    }
-}
+    expect($response->headers->get('Content-Type'))->toBe('application/vnd.api+json');
+    expect($response->getStatusCode())->toBe(200);
+});

--- a/tests/Acceptance/Http/Requests/FormRequestTest.php
+++ b/tests/Acceptance/Http/Requests/FormRequestTest.php
@@ -8,143 +8,101 @@ use BlueBeetle\ApiToolkit\Tests\Acceptance\Http\Requests\Stubs\FormRequestWithFo
 use BlueBeetle\ApiToolkit\Tests\Acceptance\Http\Requests\Stubs\FormRequestWithNoRules;
 use BlueBeetle\ApiToolkit\Tests\Acceptance\Http\Requests\Stubs\FormRequestWithQueryAndBodyRules;
 use BlueBeetle\ApiToolkit\Tests\Acceptance\Http\Requests\Stubs\FormRequestWithQueryParamRules;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
 use Illuminate\Support\Facades\Route;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
 use Symfony\Component\HttpFoundation\Response;
 
-final class FormRequestTest extends TestCase
-{
-    #[Test]
-    #[TestDox('it validates query params')]
-    public function it_validates_query_params(): void
-    {
-        Route::get('/', fn (FormRequestWithQueryParamRules $request) => response()->json(['ok' => true]));
+it('validates query params', function () {
+    Route::get('/', fn (FormRequestWithQueryParamRules $request) => response()->json(['ok' => true]));
 
-        $response = $this->get('/?include[]=category');
+    $response = $this->get('/?include[]=category');
 
-        $response->assertStatus(Response::HTTP_OK);
-    }
+    $response->assertStatus(Response::HTTP_OK);
+});
 
-    #[Test]
-    #[TestDox('it fails on missing required query param')]
-    public function it_fails_on_missing_required(): void
-    {
-        Route::get('/', fn (FormRequestWithQueryParamRules $request) => response()->json(['ok' => true]));
+it('fails on missing required query param', function () {
+    Route::get('/', fn (FormRequestWithQueryParamRules $request) => response()->json(['ok' => true]));
 
-        $response = $this->getJson('/');
+    $response = $this->getJson('/');
 
-        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
-    }
+    $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+});
 
-    #[Test]
-    #[TestDox('it rejects unknown query params')]
-    public function it_rejects_unknown_query_params(): void
-    {
-        Route::get('/', fn (FormRequestWithQueryParamRules $request) => response()->json(['ok' => true]));
+it('rejects unknown query params', function () {
+    Route::get('/', fn (FormRequestWithQueryParamRules $request) => response()->json(['ok' => true]));
 
-        $response = $this->getJson('/?include[]=category&unknown=value');
+    $response = $this->getJson('/?include[]=category&unknown=value');
 
-        $response->assertStatus(Response::HTTP_BAD_REQUEST);
-    }
+    $response->assertStatus(Response::HTTP_BAD_REQUEST);
+});
 
-    #[Test]
-    #[TestDox('it validates form data')]
-    public function it_validates_form_data(): void
-    {
-        Route::post('/', fn (FormRequestWithFormInputRules $request) => response()->json(['ok' => true]));
+it('validates form data', function () {
+    Route::post('/', fn (FormRequestWithFormInputRules $request) => response()->json(['ok' => true]));
 
-        $response = $this->postJson('/', ['name' => 'John']);
+    $response = $this->postJson('/', ['name' => 'John']);
 
-        $response->assertStatus(Response::HTTP_OK);
-    }
+    $response->assertStatus(Response::HTTP_OK);
+});
 
-    #[Test]
-    #[TestDox('it fails on missing required form field')]
-    public function it_fails_on_missing_form_field(): void
-    {
-        Route::post('/', fn (FormRequestWithFormInputRules $request) => response()->json(['ok' => true]));
+it('fails on missing required form field', function () {
+    Route::post('/', fn (FormRequestWithFormInputRules $request) => response()->json(['ok' => true]));
 
-        $response = $this->postJson('/', []);
+    $response = $this->postJson('/', []);
 
-        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
-    }
+    $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+});
 
-    #[Test]
-    #[TestDox('it rejects unknown form fields')]
-    public function it_rejects_unknown_form_fields(): void
-    {
-        Route::post('/', fn (FormRequestWithFormInputRules $request) => response()->json(['ok' => true]));
+it('rejects unknown form fields', function () {
+    Route::post('/', fn (FormRequestWithFormInputRules $request) => response()->json(['ok' => true]));
 
-        $response = $this->postJson('/', ['name' => 'John', 'unknown' => 'value']);
+    $response = $this->postJson('/', ['name' => 'John', 'unknown' => 'value']);
 
-        $response->assertStatus(Response::HTTP_BAD_REQUEST);
-    }
+    $response->assertStatus(Response::HTTP_BAD_REQUEST);
+});
 
-    #[Test]
-    #[TestDox('it passes through when no rules are defined')]
-    public function it_passes_through_with_no_rules(): void
-    {
-        Route::get('/', fn (FormRequestWithNoRules $request) => response()->json(['ok' => true]));
+it('passes through when no rules are defined', function () {
+    Route::get('/', fn (FormRequestWithNoRules $request) => response()->json(['ok' => true]));
 
-        $response = $this->getJson('/');
+    $response = $this->getJson('/');
 
-        $response->assertStatus(Response::HTTP_OK);
-    }
+    $response->assertStatus(Response::HTTP_OK);
+});
 
-    #[Test]
-    #[TestDox('it rejects multiple unknown query params with plural message')]
-    public function it_rejects_multiple_unknown_query_params(): void
-    {
-        Route::get('/', fn (FormRequestWithQueryParamRules $request) => response()->json(['ok' => true]));
+it('rejects multiple unknown query params with plural message', function () {
+    Route::get('/', fn (FormRequestWithQueryParamRules $request) => response()->json(['ok' => true]));
 
-        $response = $this->getJson('/?include[]=category&foo=bar&baz=qux');
+    $response = $this->getJson('/?include[]=category&foo=bar&baz=qux');
 
-        $response->assertStatus(Response::HTTP_BAD_REQUEST);
-    }
+    $response->assertStatus(Response::HTTP_BAD_REQUEST);
+});
 
-    #[Test]
-    #[TestDox('it rejects multiple unknown form fields with plural message')]
-    public function it_rejects_multiple_unknown_form_fields(): void
-    {
-        Route::post('/', fn (FormRequestWithFormInputRules $request) => response()->json(['ok' => true]));
+it('rejects multiple unknown form fields with plural message', function () {
+    Route::post('/', fn (FormRequestWithFormInputRules $request) => response()->json(['ok' => true]));
 
-        $response = $this->postJson('/', ['name' => 'John', 'foo' => 'bar', 'baz' => 'qux']);
+    $response = $this->postJson('/', ['name' => 'John', 'foo' => 'bar', 'baz' => 'qux']);
 
-        $response->assertStatus(Response::HTTP_BAD_REQUEST);
-    }
+    $response->assertStatus(Response::HTTP_BAD_REQUEST);
+});
 
-    #[Test]
-    #[TestDox('it validates both query params and form data together')]
-    public function it_validates_query_and_form_together(): void
-    {
-        Route::post('/', fn (FormRequestWithQueryAndBodyRules $request) => response()->json(['ok' => true]));
+it('validates both query params and form data together', function () {
+    Route::post('/', fn (FormRequestWithQueryAndBodyRules $request) => response()->json(['ok' => true]));
 
-        $response = $this->postJson('/?include[]=category', ['name' => 'John']);
+    $response = $this->postJson('/?include[]=category', ['name' => 'John']);
 
-        $response->assertStatus(Response::HTTP_OK);
-    }
+    $response->assertStatus(Response::HTTP_OK);
+});
 
-    #[Test]
-    #[TestDox('it rejects unknown query params even when form data is valid')]
-    public function it_rejects_unknown_query_with_valid_body(): void
-    {
-        Route::post('/', fn (FormRequestWithQueryAndBodyRules $request) => response()->json(['ok' => true]));
+it('rejects unknown query params even when form data is valid', function () {
+    Route::post('/', fn (FormRequestWithQueryAndBodyRules $request) => response()->json(['ok' => true]));
 
-        $response = $this->postJson('/?include[]=category&unknown=value', ['name' => 'John']);
+    $response = $this->postJson('/?include[]=category&unknown=value', ['name' => 'John']);
 
-        $response->assertStatus(Response::HTTP_BAD_REQUEST);
-    }
+    $response->assertStatus(Response::HTTP_BAD_REQUEST);
+});
 
-    #[Test]
-    #[TestDox('it rejects unknown form fields even when query params are valid')]
-    public function it_rejects_unknown_body_with_valid_query(): void
-    {
-        Route::post('/', fn (FormRequestWithQueryAndBodyRules $request) => response()->json(['ok' => true]));
+it('rejects unknown form fields even when query params are valid', function () {
+    Route::post('/', fn (FormRequestWithQueryAndBodyRules $request) => response()->json(['ok' => true]));
 
-        $response = $this->postJson('/?include[]=category', ['name' => 'John', 'unknown' => 'value']);
+    $response = $this->postJson('/?include[]=category', ['name' => 'John', 'unknown' => 'value']);
 
-        $response->assertStatus(Response::HTTP_BAD_REQUEST);
-    }
-}
+    $response->assertStatus(Response::HTTP_BAD_REQUEST);
+});

--- a/tests/Acceptance/JsonApi/ListEndpointTest.php
+++ b/tests/Acceptance/JsonApi/ListEndpointTest.php
@@ -9,201 +9,162 @@ use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\Category;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\Product;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\Tag;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Resources\ProductResource;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
 use Illuminate\Support\Facades\Route;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
 
-final class ListEndpointTest extends TestCase
-{
-    protected function setUp(): void
-    {
-        parent::setUp();
+beforeEach(function () {
+    Route::get('/api/v1/products', function () {
+        return QueryBuilder::for(Product::class, request())
+            ->fromResource(ProductResource::class)
+            ->paginate()
+        ;
+    });
+});
 
-        Route::get('/api/v1/products', function () {
-            return QueryBuilder::for(Product::class, request())
-                ->fromResource(ProductResource::class)
-                ->paginate()
-            ;
-        });
+it('returns a valid JSON:API collection response', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01']);
+    Product::create(['public_id' => 'p2', 'name' => 'Gadget', 'code' => 'G01']);
+
+    $response = $this->getJson('/api/v1/products');
+
+    $response->assertStatus(200);
+    $response->assertHeader('Content-Type', 'application/vnd.api+json');
+
+    $response->assertJsonStructure([
+        'data' => [
+            '*' => ['type', 'id', 'attributes', 'relationships', 'links', 'meta'],
+        ],
+        'meta' => ['page'],
+        'links',
+    ]);
+
+    $response->assertJsonPath('data.0.type', 'products');
+    $response->assertJsonPath('data.0.id', 'p1');
+    $response->assertJsonPath('data.0.attributes.name', 'Widget');
+    $response->assertJsonPath('data.0.attributes.code', 'W01');
+});
+
+it('includes pagination meta and links', function () {
+    for ($i = 1; $i <= 25; $i++) {
+        Product::create(['public_id' => "p{$i}", 'name' => "Product {$i}", 'code' => "C{$i}"]);
     }
 
-    #[Test]
-    #[TestDox('it returns a valid JSON:API collection response')]
-    public function it_returns_valid_collection(): void
-    {
-        Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01']);
-        Product::create(['public_id' => 'p2', 'name' => 'Gadget', 'code' => 'G01']);
+    $response = $this->getJson('/api/v1/products?page[size]=10&page[number]=2');
 
-        $response = $this->getJson('/api/v1/products');
+    $response->assertStatus(200);
+    $response->assertJsonPath('meta.page.currentPage', 2);
+    $response->assertJsonPath('meta.page.perPage', 10);
+    $response->assertJsonPath('meta.page.total', 25);
+    $response->assertJsonPath('meta.page.lastPage', 3);
 
-        $response->assertStatus(200);
-        $response->assertHeader('Content-Type', 'application/vnd.api+json');
+    $json = $response->json();
+    expect($json['data'])->toHaveCount(10);
+    expect($json['links']['prev'])->not->toBeNull();
+    expect($json['links']['next'])->not->toBeNull();
+});
 
-        $response->assertJsonStructure([
-            'data' => [
-                '*' => ['type', 'id', 'attributes', 'relationships', 'links', 'meta'],
-            ],
-            'meta' => ['page'],
-            'links',
-        ]);
+it('applies filters', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01', 'status' => 'active']);
+    Product::create(['public_id' => 'p2', 'name' => 'Gadget', 'code' => 'G01', 'status' => 'inactive']);
+    Product::create(['public_id' => 'p3', 'name' => 'Widget Pro', 'code' => 'W02', 'status' => 'active']);
 
-        $response->assertJsonPath('data.0.type', 'products');
-        $response->assertJsonPath('data.0.id', 'p1');
-        $response->assertJsonPath('data.0.attributes.name', 'Widget');
-        $response->assertJsonPath('data.0.attributes.code', 'W01');
-    }
+    $response = $this->getJson('/api/v1/products?filter[status]=active');
 
-    #[Test]
-    #[TestDox('it includes pagination meta and links')]
-    public function it_includes_pagination(): void
-    {
-        for ($i = 1; $i <= 25; $i++) {
-            Product::create(['public_id' => "p{$i}", 'name' => "Product {$i}", 'code' => "C{$i}"]);
-        }
+    $response->assertStatus(200);
+    expect($response->json('data'))->toHaveCount(2);
 
-        $response = $this->getJson('/api/v1/products?page[size]=10&page[number]=2');
+    $response = $this->getJson('/api/v1/products?filter[name]=Widget');
 
-        $response->assertStatus(200);
-        $response->assertJsonPath('meta.page.currentPage', 2);
-        $response->assertJsonPath('meta.page.perPage', 10);
-        $response->assertJsonPath('meta.page.total', 25);
-        $response->assertJsonPath('meta.page.lastPage', 3);
+    $response->assertStatus(200);
+    expect($response->json('data'))->toHaveCount(2);
+});
 
-        $json = $response->json();
-        $this->assertCount(10, $json['data']);
-        $this->assertNotNull($json['links']['prev']);
-        $this->assertNotNull($json['links']['next']);
-    }
+it('applies sorting', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Banana', 'code' => 'B01']);
+    Product::create(['public_id' => 'p2', 'name' => 'Apple', 'code' => 'A01']);
+    Product::create(['public_id' => 'p3', 'name' => 'Cherry', 'code' => 'C01']);
 
-    #[Test]
-    #[TestDox('it applies filters')]
-    public function it_applies_filters(): void
-    {
-        Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01', 'status' => 'active']);
-        Product::create(['public_id' => 'p2', 'name' => 'Gadget', 'code' => 'G01', 'status' => 'inactive']);
-        Product::create(['public_id' => 'p3', 'name' => 'Widget Pro', 'code' => 'W02', 'status' => 'active']);
+    $response = $this->getJson('/api/v1/products?sort=name');
 
-        $response = $this->getJson('/api/v1/products?filter[status]=active');
+    $response->assertStatus(200);
+    expect($response->json('data.0.attributes.name'))->toBe('Apple');
+    expect($response->json('data.1.attributes.name'))->toBe('Banana');
+    expect($response->json('data.2.attributes.name'))->toBe('Cherry');
 
-        $response->assertStatus(200);
-        $this->assertCount(2, $response->json('data'));
+    $response = $this->getJson('/api/v1/products?sort=-name');
 
-        $response = $this->getJson('/api/v1/products?filter[name]=Widget');
+    expect($response->json('data.0.attributes.name'))->toBe('Cherry');
+});
 
-        $response->assertStatus(200);
-        $this->assertCount(2, $response->json('data'));
-    }
+it('includes relationships when requested', function () {
+    $category = Category::create(['public_id' => 'c1', 'name' => 'Electronics', 'slug' => 'electronics']);
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01', 'category_id' => $category->id]);
 
-    #[Test]
-    #[TestDox('it applies sorting')]
-    public function it_applies_sorting(): void
-    {
-        Product::create(['public_id' => 'p1', 'name' => 'Banana', 'code' => 'B01']);
-        Product::create(['public_id' => 'p2', 'name' => 'Apple', 'code' => 'A01']);
-        Product::create(['public_id' => 'p3', 'name' => 'Cherry', 'code' => 'C01']);
+    $response = $this->getJson('/api/v1/products?include=category');
 
-        $response = $this->getJson('/api/v1/products?sort=name');
+    $response->assertStatus(200);
 
-        $response->assertStatus(200);
-        $this->assertSame('Apple', $response->json('data.0.attributes.name'));
-        $this->assertSame('Banana', $response->json('data.1.attributes.name'));
-        $this->assertSame('Cherry', $response->json('data.2.attributes.name'));
+    $response->assertJsonPath('data.0.relationships.category.data.type', 'categories');
+    $response->assertJsonPath('data.0.relationships.category.data.id', 'c1');
 
-        $response = $this->getJson('/api/v1/products?sort=-name');
+    $response->assertJsonStructure([
+        'included' => [
+            ['type', 'id', 'attributes'],
+        ],
+    ]);
 
-        $this->assertSame('Cherry', $response->json('data.0.attributes.name'));
-    }
+    $response->assertJsonPath('included.0.type', 'categories');
+    $response->assertJsonPath('included.0.id', 'c1');
+    $response->assertJsonPath('included.0.attributes.name', 'Electronics');
+});
 
-    #[Test]
-    #[TestDox('it includes relationships when requested')]
-    public function it_includes_relationships(): void
-    {
-        $category = Category::create(['public_id' => 'c1', 'name' => 'Electronics', 'slug' => 'electronics']);
-        Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01', 'category_id' => $category->id]);
+it('includes self link and custom links', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01']);
 
-        $response = $this->getJson('/api/v1/products?include=category');
+    $response = $this->getJson('/api/v1/products');
 
-        $response->assertStatus(200);
+    $response->assertStatus(200);
+    $response->assertJsonPath('data.0.links.self', '/api/v1/products/p1');
+    $response->assertJsonPath('data.0.links.category', '/api/v1/products/p1/category');
+});
 
-        $response->assertJsonPath('data.0.relationships.category.data.type', 'categories');
-        $response->assertJsonPath('data.0.relationships.category.data.id', 'c1');
+it('includes resource meta', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01', 'status' => 'active']);
 
-        $response->assertJsonStructure([
-            'included' => [
-                ['type', 'id', 'attributes'],
-            ],
-        ]);
+    $response = $this->getJson('/api/v1/products');
 
-        $response->assertJsonPath('included.0.type', 'categories');
-        $response->assertJsonPath('included.0.id', 'c1');
-        $response->assertJsonPath('included.0.attributes.name', 'Electronics');
-    }
+    $response->assertStatus(200);
+    $response->assertJsonPath('data.0.meta.is_available', true);
+});
 
-    #[Test]
-    #[TestDox('it includes self link and custom links')]
-    public function it_includes_links(): void
-    {
-        Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01']);
+it('returns empty data array when no results', function () {
+    $response = $this->getJson('/api/v1/products');
 
-        $response = $this->getJson('/api/v1/products');
+    $response->assertStatus(200);
+    $response->assertJsonPath('data', []);
+    $response->assertJsonPath('meta.page.total', 0);
+});
 
-        $response->assertStatus(200);
-        $response->assertJsonPath('data.0.links.self', '/api/v1/products/p1');
-        $response->assertJsonPath('data.0.links.category', '/api/v1/products/p1/category');
-    }
+it('deduplicates included resources', function () {
+    $category = Category::create(['public_id' => 'c1', 'name' => 'Electronics', 'slug' => 'electronics']);
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01', 'category_id' => $category->id]);
+    Product::create(['public_id' => 'p2', 'name' => 'Gadget', 'code' => 'G01', 'category_id' => $category->id]);
 
-    #[Test]
-    #[TestDox('it includes resource meta')]
-    public function it_includes_meta(): void
-    {
-        Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01', 'status' => 'active']);
+    $response = $this->getJson('/api/v1/products?include=category');
 
-        $response = $this->getJson('/api/v1/products');
+    $response->assertStatus(200);
+    expect($response->json('data'))->toHaveCount(2);
+    expect($response->json('included'))->toHaveCount(1);
+});
 
-        $response->assertStatus(200);
-        $response->assertJsonPath('data.0.meta.is_available', true);
-    }
+it('handles many-to-many relationships', function () {
+    $tag1 = Tag::create(['public_id' => 't1', 'name' => 'Sale']);
+    $tag2 = Tag::create(['public_id' => 't2', 'name' => 'New']);
+    $product = Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01']);
+    $product->tags()->attach([$tag1->id, $tag2->id]);
 
-    #[Test]
-    #[TestDox('it returns empty data array when no results')]
-    public function it_returns_empty_array(): void
-    {
-        $response = $this->getJson('/api/v1/products');
+    $response = $this->getJson('/api/v1/products?include=tags');
 
-        $response->assertStatus(200);
-        $response->assertJsonPath('data', []);
-        $response->assertJsonPath('meta.page.total', 0);
-    }
-
-    #[Test]
-    #[TestDox('it deduplicates included resources')]
-    public function it_deduplicates_included(): void
-    {
-        $category = Category::create(['public_id' => 'c1', 'name' => 'Electronics', 'slug' => 'electronics']);
-        Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01', 'category_id' => $category->id]);
-        Product::create(['public_id' => 'p2', 'name' => 'Gadget', 'code' => 'G01', 'category_id' => $category->id]);
-
-        $response = $this->getJson('/api/v1/products?include=category');
-
-        $response->assertStatus(200);
-        $this->assertCount(2, $response->json('data'));
-        $this->assertCount(1, $response->json('included'));
-    }
-
-    #[Test]
-    #[TestDox('it handles many-to-many relationships')]
-    public function it_handles_many_to_many(): void
-    {
-        $tag1 = Tag::create(['public_id' => 't1', 'name' => 'Sale']);
-        $tag2 = Tag::create(['public_id' => 't2', 'name' => 'New']);
-        $product = Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01']);
-        $product->tags()->attach([$tag1->id, $tag2->id]);
-
-        $response = $this->getJson('/api/v1/products?include=tags');
-
-        $response->assertStatus(200);
-        $this->assertCount(2, $response->json('data.0.relationships.tags.data'));
-        $this->assertCount(2, $response->json('included'));
-    }
-}
+    $response->assertStatus(200);
+    expect($response->json('data.0.relationships.tags.data'))->toHaveCount(2);
+    expect($response->json('included'))->toHaveCount(2);
+});

--- a/tests/Acceptance/JsonApi/NonModelEndpointTest.php
+++ b/tests/Acceptance/JsonApi/NonModelEndpointTest.php
@@ -5,197 +5,116 @@ declare(strict_types = 1);
 namespace BlueBeetle\ApiToolkit\Tests\Acceptance\JsonApi;
 
 use BlueBeetle\ApiToolkit\Http\Response;
-use BlueBeetle\ApiToolkit\Resources\Resource;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
+use BlueBeetle\ApiToolkit\Tests\Fixtures\Resources\AppInfoTestResource;
+use BlueBeetle\ApiToolkit\Tests\Fixtures\Resources\StatTestResource;
+use BlueBeetle\ApiToolkit\Tests\Fixtures\Resources\TimestampTestResource;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Route;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
 
-final class NonModelEndpointTest extends TestCase
-{
-    #[Test]
-    #[TestDox('it returns a timestamp resource without a model')]
-    public function it_returns_timestamp_resource(): void
-    {
-        $date = Carbon::create(2025, 6, 15, 10, 30, 0, 'UTC');
+it('returns a timestamp resource without a model', function () {
+    $date = Carbon::create(2025, 6, 15, 10, 30, 0, 'UTC');
 
-        Route::get('/api/v1/time', function (Response $response) use ($date) {
-            return $response->success(
-                $date,
-                TimestampTestResource::class,
-            )->respond();
-        });
+    Route::get('/api/v1/time', function (Response $response) use ($date) {
+        return $response->success(
+            $date,
+            TimestampTestResource::class,
+        )->respond();
+    });
 
-        $response = $this->getJson('/api/v1/time');
+    $response = $this->getJson('/api/v1/time');
 
-        $response->assertStatus(200);
-        $response->assertHeader('Content-Type', 'application/vnd.api+json');
-        $response->assertJsonPath('data.type', 'timestamps');
-        $response->assertJsonPath('data.attributes.string', '2025-06-15 10:30:00');
-        $response->assertJsonPath('data.attributes.timestamp', $date->timestamp);
-        $this->assertArrayHasKey('human', $response->json('data.attributes'));
-    }
+    $response->assertStatus(200);
+    $response->assertHeader('Content-Type', 'application/vnd.api+json');
+    $response->assertJsonPath('data.type', 'timestamps');
+    $response->assertJsonPath('data.attributes.string', '2025-06-15 10:30:00');
+    $response->assertJsonPath('data.attributes.timestamp', $date->timestamp);
+    expect($response->json('data.attributes'))->toHaveKey('human');
+});
 
-    #[Test]
-    #[TestDox('it returns a collection of non-model resources')]
-    public function it_returns_collection_of_non_model(): void
-    {
-        Route::get('/api/v1/stats', function (Response $response) {
-            $stats = [
-                (object) ['id' => 'daily', 'label' => 'Daily Users', 'value' => 1500],
-                (object) ['id' => 'weekly', 'label' => 'Weekly Users', 'value' => 8200],
-            ];
-
-            return $response->success($stats, StatTestResource::class)->respond();
-        });
-
-        $response = $this->getJson('/api/v1/stats');
-
-        $response->assertStatus(200);
-        $this->assertCount(2, $response->json('data'));
-        $response->assertJsonPath('data.0.type', 'stats');
-        $response->assertJsonPath('data.0.id', 'daily');
-        $response->assertJsonPath('data.0.attributes.label', 'Daily Users');
-        $response->assertJsonPath('data.0.attributes.value', 1500);
-    }
-
-    #[Test]
-    #[TestDox('it returns raw data without a resource class')]
-    public function it_returns_raw_data(): void
-    {
-        Route::get('/api/v1/health', function (Response $response) {
-            return $response->success(['status' => 'ok', 'version' => '1.0.0'])->respond();
-        });
-
-        $response = $this->getJson('/api/v1/health');
-
-        $response->assertStatus(200);
-        $response->assertJsonPath('data.status', 'ok');
-        $response->assertJsonPath('data.version', '1.0.0');
-    }
-
-    #[Test]
-    #[TestDox('it returns error responses in JSON:API format')]
-    public function it_returns_error_responses(): void
-    {
-        Route::get('/api/v1/fail', function (Response $response) {
-            return $response
-                ->error('Bad Request', 'Something went wrong', 400)
-                ->code('invalid_request')
-                ->respond()
-            ;
-        });
-
-        $response = $this->getJson('/api/v1/fail');
-
-        $response->assertStatus(400);
-        $response->assertHeader('Content-Type', 'application/vnd.api+json');
-        $response->assertJsonStructure([
-            'errors' => [
-                ['status', 'title', 'detail', 'code'],
-            ],
-        ]);
-        $response->assertJsonPath('errors.0.status', '400');
-        $response->assertJsonPath('errors.0.title', 'Bad Request');
-        $response->assertJsonPath('errors.0.detail', 'Something went wrong');
-        $response->assertJsonPath('errors.0.code', 'invalid_request');
-    }
-
-    #[Test]
-    #[TestDox('it returns error with source pointer')]
-    public function it_returns_error_with_source(): void
-    {
-        Route::get('/api/v1/fail-with-source', function (Response $response) {
-            return $response
-                ->error('Validation Error', 'Name is required', 422)
-                ->code('validation_error')
-                ->source(['pointer' => '/data/attributes/name'])
-                ->respond()
-            ;
-        });
-
-        $response = $this->getJson('/api/v1/fail-with-source');
-
-        $response->assertStatus(422);
-        $response->assertJsonPath('errors.0.source.pointer', '/data/attributes/name');
-    }
-
-    #[Test]
-    #[TestDox('it handles resource with links and meta but no model')]
-    public function it_handles_resource_with_links_and_meta(): void
-    {
-        Route::get('/api/v1/info', function (Response $response) {
-            $data = (object) ['id' => 'app', 'name' => 'My App', 'version' => '2.0'];
-
-            return $response->success($data, AppInfoTestResource::class)->respond();
-        });
-
-        $response = $this->getJson('/api/v1/info');
-
-        $response->assertStatus(200);
-        $response->assertJsonPath('data.type', 'app-info');
-        $response->assertJsonPath('data.links.self', '/api/v1/info');
-        $response->assertJsonPath('data.links.docs', 'https://docs.example.com');
-        $response->assertJsonPath('data.meta.uptime', '99.9%');
-    }
-}
-
-class TimestampTestResource extends Resource
-{
-    protected string $type = 'timestamps';
-
-    public function attributes($date): array
-    {
-        return [
-            'human' => $date->diffForHumans(),
-            'string' => $date->toDateTimeString(),
-            'timestamp' => $date->timestamp,
+it('returns a collection of non-model resources', function () {
+    Route::get('/api/v1/stats', function (Response $response) {
+        $stats = [
+            (object) ['id' => 'daily', 'label' => 'Daily Users', 'value' => 1500],
+            (object) ['id' => 'weekly', 'label' => 'Weekly Users', 'value' => 8200],
         ];
-    }
-}
 
-class StatTestResource extends Resource
-{
-    protected string $type = 'stats';
+        return $response->success($stats, StatTestResource::class)->respond();
+    });
 
-    public function attributes($stat): array
-    {
-        return [
-            'label' => $stat->label,
-            'value' => $stat->value,
-        ];
-    }
-}
+    $response = $this->getJson('/api/v1/stats');
 
-class AppInfoTestResource extends Resource
-{
-    protected string $type = 'app-info';
+    $response->assertStatus(200);
+    expect($response->json('data'))->toHaveCount(2);
+    $response->assertJsonPath('data.0.type', 'stats');
+    $response->assertJsonPath('data.0.id', 'daily');
+    $response->assertJsonPath('data.0.attributes.label', 'Daily Users');
+    $response->assertJsonPath('data.0.attributes.value', 1500);
+});
 
-    public function attributes($info): array
-    {
-        return [
-            'name' => $info->name,
-            'version' => $info->version,
-        ];
-    }
+it('returns raw data without a resource class', function () {
+    Route::get('/api/v1/health', function (Response $response) {
+        return $response->success(['status' => 'ok', 'version' => '1.0.0'])->respond();
+    });
 
-    public function self($info): string | null
-    {
-        return '/api/v1/info';
-    }
+    $response = $this->getJson('/api/v1/health');
 
-    public function links($info): array
-    {
-        return [
-            'docs' => 'https://docs.example.com',
-        ];
-    }
+    $response->assertStatus(200);
+    $response->assertJsonPath('data.status', 'ok');
+    $response->assertJsonPath('data.version', '1.0.0');
+});
 
-    public function meta($info): array
-    {
-        return [
-            'uptime' => '99.9%',
-        ];
-    }
-}
+it('returns error responses in JSON:API format', function () {
+    Route::get('/api/v1/fail', function (Response $response) {
+        return $response
+            ->error('Bad Request', 'Something went wrong', 400)
+            ->code('invalid_request')
+            ->respond()
+        ;
+    });
+
+    $response = $this->getJson('/api/v1/fail');
+
+    $response->assertStatus(400);
+    $response->assertHeader('Content-Type', 'application/vnd.api+json');
+    $response->assertJsonStructure([
+        'errors' => [
+            ['status', 'title', 'detail', 'code'],
+        ],
+    ]);
+    $response->assertJsonPath('errors.0.status', '400');
+    $response->assertJsonPath('errors.0.title', 'Bad Request');
+    $response->assertJsonPath('errors.0.detail', 'Something went wrong');
+    $response->assertJsonPath('errors.0.code', 'invalid_request');
+});
+
+it('returns error with source pointer', function () {
+    Route::get('/api/v1/fail-with-source', function (Response $response) {
+        return $response
+            ->error('Validation Error', 'Name is required', 422)
+            ->code('validation_error')
+            ->source(['pointer' => '/data/attributes/name'])
+            ->respond()
+        ;
+    });
+
+    $response = $this->getJson('/api/v1/fail-with-source');
+
+    $response->assertStatus(422);
+    $response->assertJsonPath('errors.0.source.pointer', '/data/attributes/name');
+});
+
+it('handles resource with links and meta but no model', function () {
+    Route::get('/api/v1/info', function (Response $response) {
+        $data = (object) ['id' => 'app', 'name' => 'My App', 'version' => '2.0'];
+
+        return $response->success($data, AppInfoTestResource::class)->respond();
+    });
+
+    $response = $this->getJson('/api/v1/info');
+
+    $response->assertStatus(200);
+    $response->assertJsonPath('data.type', 'app-info');
+    $response->assertJsonPath('data.links.self', '/api/v1/info');
+    $response->assertJsonPath('data.links.docs', 'https://docs.example.com');
+    $response->assertJsonPath('data.meta.uptime', '99.9%');
+});

--- a/tests/Acceptance/JsonApi/SingleEndpointTest.php
+++ b/tests/Acceptance/JsonApi/SingleEndpointTest.php
@@ -8,160 +8,127 @@ use BlueBeetle\ApiToolkit\Http\Response;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\Category;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\Product;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Resources\ProductResource;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
 use Illuminate\Support\Facades\Route;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
 
-final class SingleEndpointTest extends TestCase
-{
-    protected function setUp(): void
-    {
-        parent::setUp();
+beforeEach(function () {
+    Route::get('/api/v1/products/{product}', function (string $product, Response $response) {
+        $product = Product::where('public_id', $product)->firstOrFail();
+        $product->load(['category', 'tags']);
 
-        Route::get('/api/v1/products/{product}', function (string $product, Response $response) {
-            $product = Product::where('public_id', $product)->firstOrFail();
-            $product->load(['category', 'tags']);
+        return $response->success($product, ProductResource::class)->respond();
+    })->where('product', '[a-zA-Z0-9-]+');
+});
 
-            return $response->success($product, ProductResource::class)->respond();
-        })->where('product', '[a-zA-Z0-9-]+');
-    }
+it('returns a valid JSON:API single resource response', function () {
+    $category = Category::create(['public_id' => 'c1', 'name' => 'Electronics', 'slug' => 'electronics']);
+    Product::create([
+        'public_id' => 'p1',
+        'name' => 'Widget',
+        'code' => 'W01',
+        'description' => 'A fine widget',
+        'status' => 'active',
+        'price_in_cents' => 999,
+        'featured' => true,
+        'category_id' => $category->id,
+    ]);
 
-    #[Test]
-    #[TestDox('it returns a valid JSON:API single resource response')]
-    public function it_returns_single_resource(): void
-    {
-        $category = Category::create(['public_id' => 'c1', 'name' => 'Electronics', 'slug' => 'electronics']);
-        Product::create([
-            'public_id' => 'p1',
-            'name' => 'Widget',
-            'code' => 'W01',
-            'description' => 'A fine widget',
-            'status' => 'active',
-            'price_in_cents' => 999,
-            'featured' => true,
-            'category_id' => $category->id,
-        ]);
+    $response = $this->getJson('/api/v1/products/p1');
 
-        $response = $this->getJson('/api/v1/products/p1');
+    $response->assertStatus(200);
+    $response->assertHeader('Content-Type', 'application/vnd.api+json');
 
-        $response->assertStatus(200);
-        $response->assertHeader('Content-Type', 'application/vnd.api+json');
+    $response->assertJsonStructure([
+        'data' => ['type', 'id', 'attributes', 'relationships', 'links', 'meta'],
+    ]);
 
-        $response->assertJsonStructure([
-            'data' => ['type', 'id', 'attributes', 'relationships', 'links', 'meta'],
-        ]);
+    $response->assertJsonPath('data.type', 'products');
+    $response->assertJsonPath('data.id', 'p1');
+    $response->assertJsonPath('data.attributes.name', 'Widget');
+    $response->assertJsonPath('data.attributes.code', 'W01');
+    $response->assertJsonPath('data.attributes.description', 'A fine widget');
+    $response->assertJsonPath('data.attributes.status', 'active');
+    $response->assertJsonPath('data.attributes.price_in_cents', 999);
+    $response->assertJsonPath('data.attributes.featured', true);
+});
 
-        $response->assertJsonPath('data.type', 'products');
-        $response->assertJsonPath('data.id', 'p1');
-        $response->assertJsonPath('data.attributes.name', 'Widget');
-        $response->assertJsonPath('data.attributes.code', 'W01');
-        $response->assertJsonPath('data.attributes.description', 'A fine widget');
-        $response->assertJsonPath('data.attributes.status', 'active');
-        $response->assertJsonPath('data.attributes.price_in_cents', 999);
-        $response->assertJsonPath('data.attributes.featured', true);
-    }
+it('includes loaded relationships in response', function () {
+    $category = Category::create(['public_id' => 'c1', 'name' => 'Electronics', 'slug' => 'electronics']);
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01', 'category_id' => $category->id]);
 
-    #[Test]
-    #[TestDox('it includes loaded relationships in response')]
-    public function it_includes_loaded_relationships(): void
-    {
-        $category = Category::create(['public_id' => 'c1', 'name' => 'Electronics', 'slug' => 'electronics']);
-        Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01', 'category_id' => $category->id]);
+    $response = $this->getJson('/api/v1/products/p1');
 
-        $response = $this->getJson('/api/v1/products/p1');
+    $response->assertStatus(200);
+    $response->assertJsonPath('data.relationships.category.data.type', 'categories');
+    $response->assertJsonPath('data.relationships.category.data.id', 'c1');
+});
 
-        $response->assertStatus(200);
-        $response->assertJsonPath('data.relationships.category.data.type', 'categories');
-        $response->assertJsonPath('data.relationships.category.data.id', 'c1');
-    }
+it('includes self link', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01']);
 
-    #[Test]
-    #[TestDox('it includes self link')]
-    public function it_includes_self_link(): void
-    {
-        Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01']);
+    $response = $this->getJson('/api/v1/products/p1');
 
-        $response = $this->getJson('/api/v1/products/p1');
+    $response->assertStatus(200);
+    $response->assertJsonPath('data.links.self', '/api/v1/products/p1');
+    $response->assertJsonPath('data.links.category', '/api/v1/products/p1/category');
+});
 
-        $response->assertStatus(200);
-        $response->assertJsonPath('data.links.self', '/api/v1/products/p1');
-        $response->assertJsonPath('data.links.category', '/api/v1/products/p1/category');
-    }
+it('includes resource meta', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01', 'status' => 'active']);
 
-    #[Test]
-    #[TestDox('it includes resource meta')]
-    public function it_includes_meta(): void
-    {
-        Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01', 'status' => 'active']);
+    $response = $this->getJson('/api/v1/products/p1');
 
-        $response = $this->getJson('/api/v1/products/p1');
+    $response->assertStatus(200);
+    $response->assertJsonPath('data.meta.is_available', true);
+});
 
-        $response->assertStatus(200);
-        $response->assertJsonPath('data.meta.is_available', true);
-    }
+it('handles null relationships', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01', 'category_id' => null]);
 
-    #[Test]
-    #[TestDox('it handles null relationships')]
-    public function it_handles_null_relationships(): void
-    {
-        Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01', 'category_id' => null]);
+    $response = $this->getJson('/api/v1/products/p1');
 
-        $response = $this->getJson('/api/v1/products/p1');
+    $response->assertStatus(200);
+    $response->assertJsonPath('data.relationships.category.data', null);
+});
 
-        $response->assertStatus(200);
-        $response->assertJsonPath('data.relationships.category.data', null);
-    }
+it('returns null data for success with null', function () {
+    Route::get('/api/v1/empty', function (Response $response) {
+        return $response->success()->respond();
+    });
 
-    #[Test]
-    #[TestDox('it returns null data for success with null')]
-    public function it_returns_null_data(): void
-    {
-        Route::get('/api/v1/empty', function (Response $response) {
-            return $response->success()->respond();
-        });
+    $response = $this->getJson('/api/v1/empty');
 
-        $response = $this->getJson('/api/v1/empty');
+    $response->assertStatus(200);
+    $response->assertJsonPath('data', null);
+});
 
-        $response->assertStatus(200);
-        $response->assertJsonPath('data', null);
-    }
+it('returns custom status code', function () {
+    Route::post('/api/v1/products', function (Response $response) {
+        $product = Product::create(['public_id' => 'p1', 'name' => 'New', 'code' => 'N01']);
 
-    #[Test]
-    #[TestDox('it returns custom status code')]
-    public function it_returns_custom_status(): void
-    {
-        Route::post('/api/v1/products', function (Response $response) {
-            $product = Product::create(['public_id' => 'p1', 'name' => 'New', 'code' => 'N01']);
+        return $response->success($product, ProductResource::class)->respond(201);
+    });
 
-            return $response->success($product, ProductResource::class)->respond(201);
-        });
+    $response = $this->postJson('/api/v1/products');
 
-        $response = $this->postJson('/api/v1/products');
+    $response->assertStatus(201);
+    $response->assertJsonPath('data.type', 'products');
+});
 
-        $response->assertStatus(201);
-        $response->assertJsonPath('data.type', 'products');
-    }
+it('merges response-level meta', function () {
+    Route::get('/api/v1/products-with-meta/{product}', function (string $product, Response $response) {
+        $product = Product::where('public_id', $product)->firstOrFail();
 
-    #[Test]
-    #[TestDox('it merges response-level meta')]
-    public function it_merges_response_meta(): void
-    {
-        Route::get('/api/v1/products-with-meta/{product}', function (string $product, Response $response) {
-            $product = Product::where('public_id', $product)->firstOrFail();
+        return $response
+            ->success($product, ProductResource::class)
+            ->meta(['request_id' => 'req-123'])
+            ->respond()
+        ;
+    })->where('product', '[a-zA-Z0-9-]+');
 
-            return $response
-                ->success($product, ProductResource::class)
-                ->meta(['request_id' => 'req-123'])
-                ->respond()
-            ;
-        })->where('product', '[a-zA-Z0-9-]+');
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01']);
 
-        Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01']);
+    $response = $this->getJson('/api/v1/products-with-meta/p1');
 
-        $response = $this->getJson('/api/v1/products-with-meta/p1');
-
-        $response->assertStatus(200);
-        $response->assertJsonPath('meta.request_id', 'req-123');
-    }
-}
+    $response->assertStatus(200);
+    $response->assertJsonPath('meta.request_id', 'req-123');
+});

--- a/tests/Acceptance/OpenApi/GenerateOpenApiTest.php
+++ b/tests/Acceptance/OpenApi/GenerateOpenApiTest.php
@@ -4,259 +4,162 @@ declare(strict_types = 1);
 
 namespace BlueBeetle\ApiToolkit\Tests\Acceptance\OpenApi;
 
-use BlueBeetle\ApiToolkit\Http\Response;
 use BlueBeetle\ApiToolkit\OpenApi\DocumentBuilder;
 use BlueBeetle\ApiToolkit\OpenApi\RouteScanner;
-use BlueBeetle\ApiToolkit\QueryBuilder;
-use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\Product;
-use BlueBeetle\ApiToolkit\Tests\Fixtures\Resources\ProductResource;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
-use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
+use BlueBeetle\ApiToolkit\Tests\Fixtures\Controllers\ProductCreateController;
+use BlueBeetle\ApiToolkit\Tests\Fixtures\Controllers\ProductListController;
+use BlueBeetle\ApiToolkit\Tests\Fixtures\Controllers\ProductViewController;
 use Illuminate\Support\Facades\Route;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
 
-final class GenerateOpenApiTest extends TestCase
-{
-    private array $document;
+beforeEach(function () {
+    Route::get('/api/v1/products', [ProductListController::class, '__invoke'])
+        ->name('api.v1.products.index')
+    ;
 
-    protected function setUp(): void
-    {
-        parent::setUp();
+    Route::get('/api/v1/products/{product}', [ProductViewController::class, '__invoke'])
+        ->name('api.v1.products.show')
+    ;
 
-        Route::get('/api/v1/products', [ProductListController::class, '__invoke'])
-            ->name('api.v1.products.index')
-        ;
+    Route::post('/api/v1/products', [ProductCreateController::class, '__invoke'])
+        ->name('api.v1.products.store')
+    ;
 
-        Route::get('/api/v1/products/{product}', [ProductViewController::class, '__invoke'])
-            ->name('api.v1.products.show')
-        ;
+    $scanner = app(RouteScanner::class);
+    $endpoints = $scanner->scan();
 
-        Route::post('/api/v1/products', [ProductCreateController::class, '__invoke'])
-            ->name('api.v1.products.store')
-        ;
+    $builder = new DocumentBuilder(
+        title: 'Test API',
+        version: '1.0.0',
+        description: 'A test API',
+        servers: [['url' => 'https://api.example.com']],
+        securitySchemes: [
+            'bearerAuth' => ['type' => 'http', 'scheme' => 'bearer'],
+        ],
+        security: [['bearerAuth' => []]],
+    );
 
-        $scanner = app(RouteScanner::class);
-        $endpoints = $scanner->scan();
+    $this->document = $builder->build($endpoints);
+});
 
-        $builder = new DocumentBuilder(
-            title: 'Test API',
-            version: '1.0.0',
-            description: 'A test API',
-            servers: [['url' => 'https://api.example.com']],
-            securitySchemes: [
-                'bearerAuth' => ['type' => 'http', 'scheme' => 'bearer'],
-            ],
-            security: [['bearerAuth' => []]],
-        );
+it('generates a valid OpenAPI 3.1 document', function () {
+    expect($this->document['openapi'])->toBe('3.1.0');
+    expect($this->document['info']['title'])->toBe('Test API');
+    expect($this->document['info']['version'])->toBe('1.0.0');
+    expect($this->document['info']['description'])->toBe('A test API');
+});
 
-        $this->document = $builder->build($endpoints);
-    }
+it('includes servers', function () {
+    expect($this->document['servers'][0]['url'])->toBe('https://api.example.com');
+});
 
-    #[Test]
-    #[TestDox('it generates a valid OpenAPI 3.1 document')]
-    public function it_generates_valid_document(): void
-    {
-        $this->assertSame('3.1.0', $this->document['openapi']);
-        $this->assertSame('Test API', $this->document['info']['title']);
-        $this->assertSame('1.0.0', $this->document['info']['version']);
-        $this->assertSame('A test API', $this->document['info']['description']);
-    }
+it('includes security schemes', function () {
+    expect($this->document['components']['securitySchemes'])->toHaveKey('bearerAuth');
+    expect($this->document['components']['securitySchemes']['bearerAuth']['type'])->toBe('http');
+    expect($this->document['security'])->toBe([['bearerAuth' => []]]);
+});
 
-    #[Test]
-    #[TestDox('it includes servers')]
-    public function it_includes_servers(): void
-    {
-        $this->assertSame('https://api.example.com', $this->document['servers'][0]['url']);
-    }
+it('includes top-level tags', function () {
+    $tagNames = array_column($this->document['tags'], 'name');
 
-    #[Test]
-    #[TestDox('it includes security schemes')]
-    public function it_includes_security(): void
-    {
-        $this->assertArrayHasKey('bearerAuth', $this->document['components']['securitySchemes']);
-        $this->assertSame('http', $this->document['components']['securitySchemes']['bearerAuth']['type']);
-        $this->assertSame([['bearerAuth' => []]], $this->document['security']);
-    }
+    expect($tagNames)->toContain('Products');
+});
 
-    #[Test]
-    #[TestDox('it includes top-level tags')]
-    public function it_includes_tags(): void
-    {
-        $tagNames = array_column($this->document['tags'], 'name');
+it('generates the Product schema with attributes', function () {
+    $schema = $this->document['components']['schemas']['Product'];
 
-        $this->assertContains('Products', $tagNames);
-    }
+    expect($schema['type'])->toBe('object');
+    expect($schema['required'])->toContain('type');
+    expect($schema['required'])->toContain('id');
+    expect($schema['properties']['type']['example'])->toBe('products');
 
-    #[Test]
-    #[TestDox('it generates the Product schema with attributes')]
-    public function it_generates_product_schema(): void
-    {
-        $schema = $this->document['components']['schemas']['Product'];
+    $attributes = $schema['properties']['attributes'];
+    expect($attributes['properties']['name']['type'])->toBe('string');
+    expect($attributes['properties']['code']['type'])->toBe('string');
+    expect($attributes['properties']['price_in_cents']['type'])->toBe('integer');
+    expect($attributes['properties']['featured']['type'])->toBe('boolean');
+    expect($attributes['properties']['status']['enum'])->toBe(['active', 'inactive']);
+});
 
-        $this->assertSame('object', $schema['type']);
-        $this->assertContains('type', $schema['required']);
-        $this->assertContains('id', $schema['required']);
-        $this->assertSame('products', $schema['properties']['type']['example']);
+it('generates relationship schemas', function () {
+    $schema = $this->document['components']['schemas']['Product'];
+    $relationships = $schema['properties']['relationships'];
 
-        $attributes = $schema['properties']['attributes'];
-        $this->assertSame('string', $attributes['properties']['name']['type']);
-        $this->assertSame('string', $attributes['properties']['code']['type']);
-        $this->assertSame('integer', $attributes['properties']['price_in_cents']['type']);
-        $this->assertSame('boolean', $attributes['properties']['featured']['type']);
-        $this->assertSame(['active', 'inactive'], $attributes['properties']['status']['enum']);
-    }
+    expect($relationships['properties'])->toHaveKey('category');
+    expect($relationships['properties'])->toHaveKey('tags');
+});
 
-    #[Test]
-    #[TestDox('it generates relationship schemas')]
-    public function it_generates_relationships(): void
-    {
-        $schema = $this->document['components']['schemas']['Product'];
-        $relationships = $schema['properties']['relationships'];
+it('generates list endpoint path with query params', function () {
+    $path = $this->document['paths']['/api/v1/products']['get'];
 
-        $this->assertArrayHasKey('category', $relationships['properties']);
-        $this->assertArrayHasKey('tags', $relationships['properties']);
-    }
+    expect($path['operationId'])->toBe('api.v1.products.index');
+    expect($path['tags'])->toContain('Products');
 
-    #[Test]
-    #[TestDox('it generates list endpoint path with query params')]
-    public function it_generates_list_path(): void
-    {
-        $path = $this->document['paths']['/api/v1/products']['get'];
+    $paramNames = array_column($path['parameters'], 'name');
+    expect($paramNames)->toContain('filter[name]');
+    expect($paramNames)->toContain('filter[status]');
+    expect($paramNames)->toContain('sort');
+    expect($paramNames)->toContain('include');
+    expect($paramNames)->toContain('page[number]');
+    expect($paramNames)->toContain('page[size]');
+    expect($paramNames)->toContain('page[cursor]');
 
-        $this->assertSame('api.v1.products.index', $path['operationId']);
-        $this->assertContains('Products', $path['tags']);
+    expect($path['responses'])->toHaveKey('200');
+    expect($path['responses'])->toHaveKey('401');
+});
 
-        $paramNames = array_column($path['parameters'], 'name');
-        $this->assertContains('filter[name]', $paramNames);
-        $this->assertContains('filter[status]', $paramNames);
-        $this->assertContains('sort', $paramNames);
-        $this->assertContains('include', $paramNames);
-        $this->assertContains('page[number]', $paramNames);
-        $this->assertContains('page[size]', $paramNames);
-        $this->assertContains('page[cursor]', $paramNames);
+it('generates single endpoint path', function () {
+    $pathItem = $this->document['paths']['/api/v1/products/{product}'];
+    $path = $pathItem['get'];
 
-        $this->assertArrayHasKey('200', $path['responses']);
-        $this->assertArrayHasKey('401', $path['responses']);
-    }
+    expect($path['operationId'])->toBe('api.v1.products.show');
 
-    #[Test]
-    #[TestDox('it generates single endpoint path')]
-    public function it_generates_single_path(): void
-    {
-        $pathItem = $this->document['paths']['/api/v1/products/{product}'];
-        $path = $pathItem['get'];
+    expect($path['responses'])->toHaveKey('200');
+    expect($path['responses'])->toHaveKey('404');
+    expect($path['responses'])->toHaveKey('401');
 
-        $this->assertSame('api.v1.products.show', $path['operationId']);
+    expect($pathItem['parameters'][0]['name'])->toBe('product');
+    expect($pathItem['parameters'][0]['in'])->toBe('path');
+    expect($pathItem['parameters'][0]['required'])->toBeTrue();
+});
 
-        $this->assertArrayHasKey('200', $path['responses']);
-        $this->assertArrayHasKey('404', $path['responses']);
-        $this->assertArrayHasKey('401', $path['responses']);
+it('generates POST endpoint with 201 response', function () {
+    $path = $this->document['paths']['/api/v1/products']['post'];
 
-        // Path parameter
-        $this->assertSame('product', $pathItem['parameters'][0]['name']);
-        $this->assertSame('path', $pathItem['parameters'][0]['in']);
-        $this->assertTrue($pathItem['parameters'][0]['required']);
-    }
+    expect($path['operationId'])->toBe('api.v1.products.store');
+    expect($path['responses'])->toHaveKey('201');
+    expect($path['responses'])->toHaveKey('422');
+});
 
-    #[Test]
-    #[TestDox('it generates POST endpoint with 201 response')]
-    public function it_generates_post_path(): void
-    {
-        $path = $this->document['paths']['/api/v1/products']['post'];
+it('uses shared error response refs', function () {
+    $path = $this->document['paths']['/api/v1/products']['get'];
 
-        $this->assertSame('api.v1.products.store', $path['operationId']);
-        $this->assertArrayHasKey('201', $path['responses']);
-        $this->assertArrayHasKey('422', $path['responses']);
-    }
+    expect($path['responses']['401']['$ref'])->toBe('#/components/responses/UnauthorizedException');
 
-    #[Test]
-    #[TestDox('it uses shared error response refs')]
-    public function it_uses_shared_error_refs(): void
-    {
-        $path = $this->document['paths']['/api/v1/products']['get'];
+    expect($this->document['components']['responses'])->toHaveKey('UnauthorizedException');
+    expect($this->document['components']['responses'])->toHaveKey('NotFoundHttpException');
+    expect($this->document['components']['responses'])->toHaveKey('ValidationException');
+});
 
-        $this->assertSame(
-            '#/components/responses/UnauthorizedException',
-            $path['responses']['401']['$ref'],
-        );
+it('generates collection and single response schemas', function () {
+    $schemas = $this->document['components']['schemas'];
 
-        $this->assertArrayHasKey('UnauthorizedException', $this->document['components']['responses']);
-        $this->assertArrayHasKey('NotFoundHttpException', $this->document['components']['responses']);
-        $this->assertArrayHasKey('ValidationException', $this->document['components']['responses']);
-    }
+    expect($schemas)->toHaveKey('Product');
+    expect($schemas)->toHaveKey('ProductCollection');
+    expect($schemas)->toHaveKey('ProductResponse');
+    expect($schemas)->toHaveKey('JsonApiError');
 
-    #[Test]
-    #[TestDox('it generates collection and single response schemas')]
-    public function it_generates_response_schemas(): void
-    {
-        $schemas = $this->document['components']['schemas'];
+    expect($schemas['ProductCollection']['properties']['data']['type'])->toBe('array');
+    expect($schemas['ProductCollection']['properties']['data']['items']['$ref'])->toBe('#/components/schemas/Product');
 
-        $this->assertArrayHasKey('Product', $schemas);
-        $this->assertArrayHasKey('ProductCollection', $schemas);
-        $this->assertArrayHasKey('ProductResponse', $schemas);
-        $this->assertArrayHasKey('JsonApiError', $schemas);
+    expect($schemas['ProductResponse']['properties']['data']['$ref'])->toBe('#/components/schemas/Product');
+});
 
-        // Collection wraps in array
-        $this->assertSame('array', $schemas['ProductCollection']['properties']['data']['type']);
-        $this->assertSame('#/components/schemas/Product', $schemas['ProductCollection']['properties']['data']['items']['$ref']);
+it('generates valid JSON output', function () {
+    $json = json_encode($this->document, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
 
-        // Single wraps in data
-        $this->assertSame('#/components/schemas/Product', $schemas['ProductResponse']['properties']['data']['$ref']);
-    }
+    expect($json)->not->toBeFalse();
+    $this->assertJson($json);
 
-    #[Test]
-    #[TestDox('it generates valid JSON output')]
-    public function it_generates_valid_json(): void
-    {
-        $json = json_encode($this->document, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
-
-        $this->assertNotFalse($json);
-        $this->assertJson($json);
-
-        $decoded = json_decode($json, true);
-        $this->assertSame('3.1.0', $decoded['openapi']);
-    }
-}
-
-final class ProductListController
-{
-    public function __invoke(Request $request, Response $response): JsonResponse
-    {
-        $products = QueryBuilder::for(Product::class, $request)
-            ->fromResource(ProductResource::class)
-            ->paginate()
-        ;
-
-        return $response->success($products, ProductResource::class)->respond();
-    }
-}
-
-final class ProductViewController
-{
-    public function __invoke(Product $product, Response $response): JsonResponse
-    {
-        return $response->success($product, ProductResource::class)->respond();
-    }
-}
-
-final class ProductCreateController
-{
-    public function __invoke(Request $request, Response $response): JsonResponse
-    {
-        $product = Product::create($request->all());
-
-        return $response->success($product, ProductResource::class)->respond(201);
-    }
-}
-
-final class ProductDeleteController
-{
-    public function __invoke(Product $product, Response $response): JsonResponse
-    {
-        $product->delete();
-
-        return $response->success()->respond(204);
-    }
-}
+    $decoded = json_decode($json, true);
+    expect($decoded['openapi'])->toBe('3.1.0');
+});

--- a/tests/Feature/Console/GenerateOpenApiCommandTest.php
+++ b/tests/Feature/Console/GenerateOpenApiCommandTest.php
@@ -6,172 +6,139 @@ namespace BlueBeetle\ApiToolkit\Tests\Feature\Console;
 
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Controllers\StubListController;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Controllers\StubShowController;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
 use Illuminate\Support\Facades\Route;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
 
-final class GenerateOpenApiCommandTest extends TestCase
-{
-    protected function tearDown(): void
-    {
-        $files = [
-            base_path('openapi.json'),
-            base_path('custom-output.json'),
-        ];
+afterEach(function () {
+    $files = [
+        base_path('openapi.json'),
+        base_path('custom-output.json'),
+    ];
 
-        foreach ($files as $file) {
-            if (file_exists($file)) {
-                unlink($file);
-            }
+    foreach ($files as $file) {
+        if (file_exists($file)) {
+            unlink($file);
         }
-
-        parent::tearDown();
     }
+});
 
-    #[Test]
-    #[TestDox('it warns when no endpoints are found')]
-    public function it_warns_when_no_endpoints(): void
-    {
-        $this->artisan('api-toolkit:openapi')
-            ->expectsOutputToContain('No API Toolkit endpoints found')
-            ->assertSuccessful()
-        ;
+it('warns when no endpoints are found', function () {
+    $this->artisan('api-toolkit:openapi')
+        ->expectsOutputToContain('No API Toolkit endpoints found')
+        ->assertSuccessful()
+    ;
 
-        $this->assertFileDoesNotExist(base_path('openapi.json'));
-    }
+    expect(base_path('openapi.json'))->not->toBeFile();
+});
 
-    #[Test]
-    #[TestDox('it generates openapi.json with default output path')]
-    public function it_generates_default_output(): void
-    {
-        $this->registerRoutes();
+it('generates openapi.json with default output path', function () {
+    registerRoutes();
 
-        $this->artisan('api-toolkit:openapi')
-            ->expectsOutputToContain('endpoint(s)')
-            ->expectsOutputToContain('OpenAPI spec written to openapi.json')
-            ->assertSuccessful()
-        ;
+    $this->artisan('api-toolkit:openapi')
+        ->expectsOutputToContain('endpoint(s)')
+        ->expectsOutputToContain('OpenAPI spec written to openapi.json')
+        ->assertSuccessful()
+    ;
 
-        $this->assertFileExists(base_path('openapi.json'));
+    expect(base_path('openapi.json'))->toBeFile();
 
-        $content = json_decode(file_get_contents(base_path('openapi.json')), true);
-        $this->assertSame('3.1.0', $content['openapi']);
-    }
+    $content = json_decode(file_get_contents(base_path('openapi.json')), true);
+    expect($content['openapi'])->toBe('3.1.0');
+});
 
-    #[Test]
-    #[TestDox('it generates to custom output path')]
-    public function it_generates_custom_output(): void
-    {
-        $this->registerRoutes();
+it('generates to custom output path', function () {
+    registerRoutes();
 
-        $this->artisan('api-toolkit:openapi', ['--output' => 'custom-output.json'])
-            ->expectsOutputToContain('OpenAPI spec written to custom-output.json')
-            ->assertSuccessful()
-        ;
+    $this->artisan('api-toolkit:openapi', ['--output' => 'custom-output.json'])
+        ->expectsOutputToContain('OpenAPI spec written to custom-output.json')
+        ->assertSuccessful()
+    ;
 
-        $this->assertFileExists(base_path('custom-output.json'));
+    expect(base_path('custom-output.json'))->toBeFile();
 
-        $content = json_decode(file_get_contents(base_path('custom-output.json')), true);
-        $this->assertSame('3.1.0', $content['openapi']);
-    }
+    $content = json_decode(file_get_contents(base_path('custom-output.json')), true);
+    expect($content['openapi'])->toBe('3.1.0');
+});
 
-    #[Test]
-    #[TestDox('it generates pretty-printed JSON with --pretty flag')]
-    public function it_generates_pretty_json(): void
-    {
-        $this->registerRoutes();
+it('generates pretty-printed JSON with --pretty flag', function () {
+    registerRoutes();
 
-        $this->artisan('api-toolkit:openapi', ['--pretty' => true])
-            ->assertSuccessful()
-        ;
+    $this->artisan('api-toolkit:openapi', ['--pretty' => true])
+        ->assertSuccessful()
+    ;
 
-        $raw = file_get_contents(base_path('openapi.json'));
-        $this->assertStringContainsString("\n", $raw);
-        $this->assertStringContainsString('    ', $raw);
-    }
+    $raw = file_get_contents(base_path('openapi.json'));
+    expect($raw)->toContain("\n");
+    expect($raw)->toContain('    ');
+});
 
-    #[Test]
-    #[TestDox('it generates compact JSON without --pretty flag')]
-    public function it_generates_compact_json(): void
-    {
-        $this->registerRoutes();
+it('generates compact JSON without --pretty flag', function () {
+    registerRoutes();
 
-        $this->artisan('api-toolkit:openapi')
-            ->assertSuccessful()
-        ;
+    $this->artisan('api-toolkit:openapi')
+        ->assertSuccessful()
+    ;
 
-        $raw = file_get_contents(base_path('openapi.json'));
-        $this->assertStringNotContainsString("\n", $raw);
-    }
+    $raw = file_get_contents(base_path('openapi.json'));
+    expect($raw)->not->toContain("\n");
+});
 
-    #[Test]
-    #[TestDox('it reads openapi config values')]
-    public function it_reads_config(): void
-    {
-        $this->app['config']->set('api-toolkit.openapi', [
-            'title' => 'My Custom API',
-            'version' => '2.5.0',
-            'description' => 'Custom description',
-            'servers' => [['url' => 'https://custom.example.com']],
-            'security_schemes' => [
-                'bearerAuth' => ['type' => 'http', 'scheme' => 'bearer'],
-            ],
-            'security' => [['bearerAuth' => []]],
-        ]);
+it('reads openapi config values', function () {
+    $this->app['config']->set('api-toolkit.openapi', [
+        'title' => 'My Custom API',
+        'version' => '2.5.0',
+        'description' => 'Custom description',
+        'servers' => [['url' => 'https://custom.example.com']],
+        'security_schemes' => [
+            'bearerAuth' => ['type' => 'http', 'scheme' => 'bearer'],
+        ],
+        'security' => [['bearerAuth' => []]],
+    ]);
 
-        $this->registerRoutes();
+    registerRoutes();
 
-        $this->artisan('api-toolkit:openapi', ['--pretty' => true])
-            ->assertSuccessful()
-        ;
+    $this->artisan('api-toolkit:openapi', ['--pretty' => true])
+        ->assertSuccessful()
+    ;
 
-        $content = json_decode(file_get_contents(base_path('openapi.json')), true);
-        $this->assertSame('My Custom API', $content['info']['title']);
-        $this->assertSame('2.5.0', $content['info']['version']);
-        $this->assertSame('Custom description', $content['info']['description']);
-        $this->assertSame('https://custom.example.com', $content['servers'][0]['url']);
-        $this->assertArrayHasKey('bearerAuth', $content['components']['securitySchemes']);
-        $this->assertSame([['bearerAuth' => []]], $content['security']);
-    }
+    $content = json_decode(file_get_contents(base_path('openapi.json')), true);
+    expect($content['info']['title'])->toBe('My Custom API');
+    expect($content['info']['version'])->toBe('2.5.0');
+    expect($content['info']['description'])->toBe('Custom description');
+    expect($content['servers'][0]['url'])->toBe('https://custom.example.com');
+    expect($content['components']['securitySchemes'])->toHaveKey('bearerAuth');
+    expect($content['security'])->toBe([['bearerAuth' => []]]);
+});
 
-    #[Test]
-    #[TestDox('it uses app name as fallback title')]
-    public function it_uses_app_name_fallback(): void
-    {
-        $this->app['config']->set('app.name', 'Fallback App');
-        $this->app['config']->set('api-toolkit.openapi', []);
+it('uses app name as fallback title', function () {
+    $this->app['config']->set('app.name', 'Fallback App');
+    $this->app['config']->set('api-toolkit.openapi', []);
 
-        $this->registerRoutes();
+    registerRoutes();
 
-        $this->artisan('api-toolkit:openapi')
-            ->assertSuccessful()
-        ;
+    $this->artisan('api-toolkit:openapi')
+        ->assertSuccessful()
+    ;
 
-        $content = json_decode(file_get_contents(base_path('openapi.json')), true);
-        $this->assertSame('Fallback App', $content['info']['title']);
-    }
+    $content = json_decode(file_get_contents(base_path('openapi.json')), true);
+    expect($content['info']['title'])->toBe('Fallback App');
+});
 
-    #[Test]
-    #[TestDox('it reports the correct endpoint count')]
-    public function it_reports_endpoint_count(): void
-    {
-        $this->registerRoutes();
+it('reports the correct endpoint count', function () {
+    registerRoutes();
 
-        $this->artisan('api-toolkit:openapi')
-            ->expectsOutputToContain('Found 2 endpoint(s)')
-            ->assertSuccessful()
-        ;
-    }
+    $this->artisan('api-toolkit:openapi')
+        ->expectsOutputToContain('Found 2 endpoint(s)')
+        ->assertSuccessful()
+    ;
+});
 
-    private function registerRoutes(): void
-    {
-        Route::get('/api/v1/products', [StubListController::class, '__invoke'])
-            ->name('api.v1.products.index')
-        ;
+function registerRoutes(): void
+{
+    Route::get('/api/v1/products', [StubListController::class, '__invoke'])
+        ->name('api.v1.products.index')
+    ;
 
-        Route::get('/api/v1/products/{product}', [StubShowController::class, '__invoke'])
-            ->name('api.v1.products.show')
-        ;
-    }
+    Route::get('/api/v1/products/{product}', [StubShowController::class, '__invoke'])
+        ->name('api.v1.products.show')
+    ;
 }

--- a/tests/Feature/Console/MakeResourceCommandTest.php
+++ b/tests/Feature/Console/MakeResourceCommandTest.php
@@ -4,144 +4,105 @@ declare(strict_types = 1);
 
 namespace BlueBeetle\ApiToolkit\Tests\Feature\Console;
 
-use BlueBeetle\ApiToolkit\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
+beforeEach(function () {
+    $this->resourcePath = app_path('Http/Resources');
+});
 
-final class MakeResourceCommandTest extends TestCase
-{
-    private string $resourcePath;
+afterEach(function () {
+    $files = glob($this->resourcePath.'/*.php');
 
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->resourcePath = app_path('Http/Resources');
+    foreach ($files as $file) {
+        unlink($file);
     }
 
-    protected function tearDown(): void
-    {
-        $files = glob($this->resourcePath.'/*.php');
-
-        foreach ($files as $file) {
-            unlink($file);
-        }
-
-        if (is_dir($this->resourcePath)) {
-            rmdir($this->resourcePath);
-        }
-
-        $parentDir = app_path('Http');
-
-        if (is_dir($parentDir) && count(glob($parentDir.'/*')) === 0) {
-            rmdir($parentDir);
-        }
-
-        parent::tearDown();
+    if (is_dir($this->resourcePath)) {
+        rmdir($this->resourcePath);
     }
 
-    #[Test]
-    #[TestDox('it creates a resource with a model')]
-    public function it_creates_resource_with_model(): void
-    {
-        $this->artisan('api-toolkit:make-resource', ['name' => 'Product'])
-            ->assertSuccessful()
-        ;
+    $parentDir = app_path('Http');
 
-        $this->assertFileExists($this->resourcePath.'/ProductResource.php');
-
-        $content = file_get_contents($this->resourcePath.'/ProductResource.php');
-        $this->assertStringContainsString('class ProductResource extends Resource', $content);
-        $this->assertStringContainsString('App\Models\Product', $content);
-        $this->assertStringContainsString('Product::class', $content);
+    if (is_dir($parentDir) && count(glob($parentDir.'/*')) === 0) {
+        rmdir($parentDir);
     }
+});
 
-    #[Test]
-    #[TestDox('it creates a resource with explicit model option')]
-    public function it_creates_with_explicit_model(): void
-    {
-        $this->artisan('api-toolkit:make-resource', [
-            'name' => 'Item',
-            '--model' => 'App\Domain\Models\Item',
-        ])->assertSuccessful();
+it('creates a resource with a model', function () {
+    $this->artisan('api-toolkit:make-resource', ['name' => 'Product'])
+        ->assertSuccessful()
+    ;
 
-        $content = file_get_contents($this->resourcePath.'/ItemResource.php');
-        $this->assertStringContainsString('App\Domain\Models\Item', $content);
-    }
+    expect($this->resourcePath.'/ProductResource.php')->toBeFile();
 
-    #[Test]
-    #[TestDox('it creates a plain resource without a model')]
-    public function it_creates_plain_resource(): void
-    {
-        $this->artisan('api-toolkit:make-resource', [
-            'name' => 'Timestamp',
-            '--plain' => true,
-        ])->assertSuccessful();
+    $content = file_get_contents($this->resourcePath.'/ProductResource.php');
+    expect($content)->toContain('class ProductResource extends Resource');
+    expect($content)->toContain('App\Models\Product');
+    expect($content)->toContain('Product::class');
+});
 
-        $content = file_get_contents($this->resourcePath.'/TimestampResource.php');
-        $this->assertStringContainsString('class TimestampResource extends Resource', $content);
-        $this->assertStringContainsString("type = 'timestamp'", $content);
-        $this->assertStringNotContainsString('$model =', $content);
-    }
+it('creates a resource with explicit model option', function () {
+    $this->artisan('api-toolkit:make-resource', [
+        'name' => 'Item',
+        '--model' => 'App\Domain\Models\Item',
+    ])->assertSuccessful();
 
-    #[Test]
-    #[TestDox('it appends Resource suffix when not provided')]
-    public function it_appends_resource_suffix(): void
-    {
-        $this->artisan('api-toolkit:make-resource', ['name' => 'Category'])
-            ->assertSuccessful()
-        ;
+    $content = file_get_contents($this->resourcePath.'/ItemResource.php');
+    expect($content)->toContain('App\Domain\Models\Item');
+});
 
-        $this->assertFileExists($this->resourcePath.'/CategoryResource.php');
-    }
+it('creates a plain resource without a model', function () {
+    $this->artisan('api-toolkit:make-resource', [
+        'name' => 'Timestamp',
+        '--plain' => true,
+    ])->assertSuccessful();
 
-    #[Test]
-    #[TestDox('it does not duplicate Resource suffix')]
-    public function it_does_not_duplicate_suffix(): void
-    {
-        $this->artisan('api-toolkit:make-resource', ['name' => 'CategoryResource'])
-            ->assertSuccessful()
-        ;
+    $content = file_get_contents($this->resourcePath.'/TimestampResource.php');
+    expect($content)->toContain('class TimestampResource extends Resource');
+    expect($content)->toContain("type = 'timestamp'");
+    expect($content)->not->toContain('$model =');
+});
 
-        $this->assertFileExists($this->resourcePath.'/CategoryResource.php');
-        $this->assertFileDoesNotExist($this->resourcePath.'/CategoryResourceResource.php');
-    }
+it('appends Resource suffix when not provided', function () {
+    $this->artisan('api-toolkit:make-resource', ['name' => 'Category'])
+        ->assertSuccessful()
+    ;
 
-    #[Test]
-    #[TestDox('it fails when resource already exists')]
-    public function it_fails_when_resource_exists(): void
-    {
-        $this->artisan('api-toolkit:make-resource', ['name' => 'Product'])
-            ->assertSuccessful()
-        ;
+    expect($this->resourcePath.'/CategoryResource.php')->toBeFile();
+});
 
-        $this->artisan('api-toolkit:make-resource', ['name' => 'Product'])
-            ->assertFailed()
-        ;
-    }
+it('does not duplicate Resource suffix', function () {
+    $this->artisan('api-toolkit:make-resource', ['name' => 'CategoryResource'])
+        ->assertSuccessful()
+    ;
 
-    #[Test]
-    #[TestDox('it derives type name for plain resources')]
-    public function it_derives_type_name(): void
-    {
-        $this->artisan('api-toolkit:make-resource', [
-            'name' => 'UserProfile',
-            '--plain' => true,
-        ])->assertSuccessful();
+    expect($this->resourcePath.'/CategoryResource.php')->toBeFile();
+    expect($this->resourcePath.'/CategoryResourceResource.php')->not->toBeFile();
+});
 
-        $content = file_get_contents($this->resourcePath.'/UserProfileResource.php');
-        $this->assertStringContainsString("type = 'user-profile'", $content);
-    }
+it('fails when resource already exists', function () {
+    $this->artisan('api-toolkit:make-resource', ['name' => 'Product'])
+        ->assertSuccessful()
+    ;
 
-    #[Test]
-    #[TestDox('it uses camelCase variable name for model')]
-    public function it_uses_camel_case_variable(): void
-    {
-        $this->artisan('api-toolkit:make-resource', ['name' => 'ProductCategory'])
-            ->assertSuccessful()
-        ;
+    $this->artisan('api-toolkit:make-resource', ['name' => 'Product'])
+        ->assertFailed()
+    ;
+});
 
-        $content = file_get_contents($this->resourcePath.'/ProductCategoryResource.php');
-        $this->assertStringContainsString('$productCategory', $content);
-    }
-}
+it('derives type name for plain resources', function () {
+    $this->artisan('api-toolkit:make-resource', [
+        'name' => 'UserProfile',
+        '--plain' => true,
+    ])->assertSuccessful();
+
+    $content = file_get_contents($this->resourcePath.'/UserProfileResource.php');
+    expect($content)->toContain("type = 'user-profile'");
+});
+
+it('uses camelCase variable name for model', function () {
+    $this->artisan('api-toolkit:make-resource', ['name' => 'ProductCategory'])
+        ->assertSuccessful()
+    ;
+
+    $content = file_get_contents($this->resourcePath.'/ProductCategoryResource.php');
+    expect($content)->toContain('$productCategory');
+});

--- a/tests/Feature/OpenApi/DocumentBuilderTest.php
+++ b/tests/Feature/OpenApi/DocumentBuilderTest.php
@@ -17,828 +17,64 @@ use BlueBeetle\ApiToolkit\Tests\Fixtures\Requests\DocBuilderStubPipeRulesFormReq
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Requests\DocBuilderStubThrowingFormRequest;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Requests\DocBuilderStubTypedFormRequest;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Resources\OpenApiStubResource;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
 
-final class DocumentBuilderTest extends TestCase
+function makeListEndpoint(): EndpointDefinition
 {
-    #[Test]
-    #[TestDox('it builds a valid OpenAPI 3.1 document')]
-    public function it_builds_valid_document(): void
-    {
-        $builder = new DocumentBuilder(
-            title: 'Test API',
-            version: '2.0.0',
-            description: 'A test API',
-        );
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs',
-                httpMethods: ['GET'],
-                resourceClass: OpenApiStubResource::class,
-                isList: true,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'index',
-                formRequestClass: null,
-                routeName: 'api.v1.stubs.index',
-            ),
-            new EndpointDefinition(
-                path: '/api/v1/stubs/{stub}',
-                httpMethods: ['GET'],
-                resourceClass: OpenApiStubResource::class,
-                isList: false,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'show',
-                formRequestClass: null,
-                routeName: 'api.v1.stubs.show',
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $this->assertSame('3.1.0', $document['openapi']);
-        $this->assertSame('Test API', $document['info']['title']);
-        $this->assertSame('2.0.0', $document['info']['version']);
-        $this->assertSame('A test API', $document['info']['description']);
-    }
-
-    #[Test]
-    #[TestDox('it generates paths for list endpoints')]
-    public function it_generates_list_paths(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs',
-                httpMethods: ['GET'],
-                resourceClass: OpenApiStubResource::class,
-                isList: true,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'index',
-                formRequestClass: null,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $this->assertArrayHasKey('/api/v1/stubs', $document['paths']);
-        $this->assertArrayHasKey('get', $document['paths']['/api/v1/stubs']);
-        $this->assertArrayHasKey('parameters', $document['paths']['/api/v1/stubs']['get']);
-    }
-
-    #[Test]
-    #[TestDox('it generates paths for single resource endpoints')]
-    public function it_generates_single_paths(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs/{stub}',
-                httpMethods: ['GET'],
-                resourceClass: OpenApiStubResource::class,
-                isList: false,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'show',
-                formRequestClass: null,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $path = $document['paths']['/api/v1/stubs/{stub}'];
-
-        $this->assertArrayHasKey('get', $path);
-        $this->assertArrayHasKey('parameters', $path);
-        $this->assertSame('stub', $path['parameters'][0]['name']);
-        $this->assertSame('path', $path['parameters'][0]['in']);
-    }
-
-    #[Test]
-    #[TestDox('it registers resource schemas in components')]
-    public function it_registers_schemas(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs',
-                httpMethods: ['GET'],
-                resourceClass: OpenApiStubResource::class,
-                isList: true,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'index',
-                formRequestClass: null,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $this->assertArrayHasKey('OpenApiStub', $document['components']['schemas']);
-        $this->assertArrayHasKey('OpenApiStubCollection', $document['components']['schemas']);
-        $this->assertArrayHasKey('JsonApiError', $document['components']['schemas']);
-    }
-
-    #[Test]
-    #[TestDox('it generates correct tags')]
-    public function it_generates_tags(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs',
-                httpMethods: ['GET'],
-                resourceClass: OpenApiStubResource::class,
-                isList: true,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'index',
-                formRequestClass: null,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $this->assertSame(['Open Api Stubs'], $document['paths']['/api/v1/stubs']['get']['tags']);
-    }
-
-    #[Test]
-    #[TestDox('it handles POST endpoints with 201 status')]
-    public function it_handles_post_endpoints(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs',
-                httpMethods: ['POST'],
-                resourceClass: OpenApiStubResource::class,
-                isList: false,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'store',
-                formRequestClass: null,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $responses = $document['paths']['/api/v1/stubs']['post']['responses'];
-
-        $this->assertArrayHasKey('201', $responses);
-        $this->assertArrayHasKey('422', $responses);
-    }
-
-    #[Test]
-    #[TestDox('it handles DELETE endpoints with 204 status')]
-    public function it_handles_delete_endpoints(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs/{stub}',
-                httpMethods: ['DELETE'],
-                resourceClass: OpenApiStubResource::class,
-                isList: false,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'destroy',
-                formRequestClass: null,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $responses = $document['paths']['/api/v1/stubs/{stub}']['delete']['responses'];
-
-        $this->assertArrayHasKey('204', $responses);
-    }
-
-    #[Test]
-    #[TestDox('it omits description when empty')]
-    public function it_omits_empty_description(): void
-    {
-        $builder = new DocumentBuilder(title: 'API', version: '1.0.0', description: '');
-
-        $document = $builder->build([$this->makeListEndpoint()]);
-
-        $this->assertArrayNotHasKey('description', $document['info']);
-    }
-
-    #[Test]
-    #[TestDox('it omits servers when empty')]
-    public function it_omits_empty_servers(): void
-    {
-        $builder = new DocumentBuilder(servers: []);
-
-        $document = $builder->build([$this->makeListEndpoint()]);
-
-        $this->assertArrayNotHasKey('servers', $document);
-    }
-
-    #[Test]
-    #[TestDox('it omits security when empty')]
-    public function it_omits_empty_security(): void
-    {
-        $builder = new DocumentBuilder(security: []);
-
-        $document = $builder->build([$this->makeListEndpoint()]);
-
-        $this->assertArrayNotHasKey('security', $document);
-    }
-
-    #[Test]
-    #[TestDox('it omits securitySchemes when empty')]
-    public function it_omits_empty_security_schemes(): void
-    {
-        $builder = new DocumentBuilder(securitySchemes: []);
-
-        $document = $builder->build([$this->makeListEndpoint()]);
-
-        $this->assertArrayNotHasKey('securitySchemes', $document['components']);
-    }
-
-    #[Test]
-    #[TestDox('it does not duplicate tags for same resource')]
-    public function it_deduplicates_tags(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            $this->makeListEndpoint(),
-            new EndpointDefinition(
-                path: '/api/v1/stubs/{stub}',
-                httpMethods: ['GET'],
-                resourceClass: OpenApiStubResource::class,
-                isList: false,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'show',
-                formRequestClass: null,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $tagNames = array_column($document['tags'], 'name');
-        $this->assertCount(1, $tagNames);
-        $this->assertSame('Open Api Stubs', $tagNames[0]);
-    }
-
-    #[Test]
-    #[TestDox('it omits operationId when route has no name')]
-    public function it_omits_operation_id_without_route_name(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs',
-                httpMethods: ['GET'],
-                resourceClass: OpenApiStubResource::class,
-                isList: true,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'index',
-                formRequestClass: null,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $this->assertArrayNotHasKey('operationId', $document['paths']['/api/v1/stubs']['get']);
-    }
-
-    #[Test]
-    #[TestDox('it generates PUT/PATCH summary')]
-    public function it_generates_put_patch_summary(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs/{stub}',
-                httpMethods: ['PUT', 'PATCH'],
-                resourceClass: OpenApiStubResource::class,
-                isList: false,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'update',
-                formRequestClass: null,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $this->assertSame('Update Open Api Stub', $document['paths']['/api/v1/stubs/{stub}']['put']['summary']);
-        $this->assertSame('Update Open Api Stub', $document['paths']['/api/v1/stubs/{stub}']['patch']['summary']);
-    }
-
-    #[Test]
-    #[TestDox('it generates DELETE summary')]
-    public function it_generates_delete_summary(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs/{stub}',
-                httpMethods: ['DELETE'],
-                resourceClass: OpenApiStubResource::class,
-                isList: false,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'destroy',
-                formRequestClass: null,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $this->assertSame('Delete Open Api Stub', $document['paths']['/api/v1/stubs/{stub}']['delete']['summary']);
-    }
-
-    #[Test]
-    #[TestDox('it converts optional path parameters')]
-    public function it_converts_optional_path_params(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs/{stub?}',
-                httpMethods: ['GET'],
-                resourceClass: OpenApiStubResource::class,
-                isList: false,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'show',
-                formRequestClass: null,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        // Optional param should have ? removed
-        $this->assertArrayHasKey('/api/v1/stubs/{stub}', $document['paths']);
-    }
-
-    #[Test]
-    #[TestDox('it generates path parameter description matching resource name')]
-    public function it_generates_matching_param_description(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs/{stub}',
-                httpMethods: ['GET'],
-                resourceClass: OpenApiStubResource::class,
-                isList: false,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'show',
-                formRequestClass: null,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $params = $document['paths']['/api/v1/stubs/{stub}']['parameters'];
-        // 'stub' matches resource name 'OpenApiStub' headline → should get "The Stub ID" or similar
-        $this->assertArrayHasKey('description', $params[0]);
-    }
-
-    #[Test]
-    #[TestDox('it generates non-matching path parameter description')]
-    public function it_generates_non_matching_param_description(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs/{category_id}',
-                httpMethods: ['GET'],
-                resourceClass: OpenApiStubResource::class,
-                isList: false,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'show',
-                formRequestClass: null,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $params = $document['paths']['/api/v1/stubs/{category_id}']['parameters'];
-        $this->assertStringContainsString('Category Id', $params[0]['description']);
-    }
-
-    #[Test]
-    #[TestDox('it builds request body from form request rules')]
-    public function it_builds_request_body(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs',
-                httpMethods: ['POST'],
-                resourceClass: OpenApiStubResource::class,
-                isList: false,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'store',
-                formRequestClass: DocBuilderStubFormRequest::class,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $requestBody = $document['paths']['/api/v1/stubs']['post']['requestBody'];
-
-        $this->assertTrue($requestBody['required']);
-        $schema = $requestBody['content']['application/json']['schema'];
-        $this->assertSame('object', $schema['type']);
-        $this->assertArrayHasKey('name', $schema['properties']);
-        $this->assertArrayHasKey('email', $schema['properties']);
-        $this->assertContains('name', $schema['required']);
-    }
-
-    #[Test]
-    #[TestDox('it maps form rules to OpenAPI types')]
-    public function it_maps_rules_to_openapi_types(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs',
-                httpMethods: ['POST'],
-                resourceClass: OpenApiStubResource::class,
-                isList: false,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'store',
-                formRequestClass: DocBuilderStubTypedFormRequest::class,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $schema = $document['paths']['/api/v1/stubs']['post']['requestBody']['content']['application/json']['schema'];
-        $props = $schema['properties'];
-
-        $this->assertSame('integer', $props['age']['type']);
-        $this->assertSame('boolean', $props['active']['type']);
-        $this->assertSame('string', $props['email']['type']);
-        $this->assertSame('email', $props['email']['format']);
-        $this->assertSame('string', $props['website']['type']);
-        $this->assertSame('uri', $props['website']['format']);
-        $this->assertSame('string', $props['birthday']['type']);
-        $this->assertSame('date', $props['birthday']['format']);
-        $this->assertSame('array', $props['tags']['type']);
-        $this->assertTrue($props['description']['nullable']);
-    }
-
-    #[Test]
-    #[TestDox('it maps min and max rules to schema constraints')]
-    public function it_maps_min_max_rules(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs',
-                httpMethods: ['POST'],
-                resourceClass: OpenApiStubResource::class,
-                isList: false,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'store',
-                formRequestClass: DocBuilderStubMinMaxFormRequest::class,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $props = $document['paths']['/api/v1/stubs']['post']['requestBody']['content']['application/json']['schema']['properties'];
-
-        $this->assertSame(3, $props['name']['minLength']);
-        $this->assertSame(255, $props['name']['maxLength']);
-    }
-
-    #[Test]
-    #[TestDox('it skips nested dot-notation rules in request body')]
-    public function it_skips_nested_rules(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs',
-                httpMethods: ['POST'],
-                resourceClass: OpenApiStubResource::class,
-                isList: false,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'store',
-                formRequestClass: DocBuilderStubNestedFormRequest::class,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $props = $document['paths']['/api/v1/stubs']['post']['requestBody']['content']['application/json']['schema']['properties'];
-
-        $this->assertArrayHasKey('items', $props);
-        $this->assertArrayNotHasKey('items.name', $props);
-    }
-
-    #[Test]
-    #[TestDox('it omits request body when form request has no rules')]
-    public function it_omits_empty_request_body(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs',
-                httpMethods: ['POST'],
-                resourceClass: OpenApiStubResource::class,
-                isList: false,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'store',
-                formRequestClass: DocBuilderStubEmptyFormRequest::class,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $this->assertArrayNotHasKey('requestBody', $document['paths']['/api/v1/stubs']['post']);
-    }
-
-    #[Test]
-    #[TestDox('it includes 422 for PUT/PATCH endpoints')]
-    public function it_includes_validation_error_for_put_patch(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs/{stub}',
-                httpMethods: ['PUT'],
-                resourceClass: OpenApiStubResource::class,
-                isList: false,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'update',
-                formRequestClass: null,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $responses = $document['paths']['/api/v1/stubs/{stub}']['put']['responses'];
-
-        $this->assertArrayHasKey('422', $responses);
-        $this->assertArrayHasKey('401', $responses);
-        $this->assertArrayHasKey('404', $responses);
-    }
-
-    #[Test]
-    #[TestDox('list endpoints do not include 404 response')]
-    public function it_omits_404_for_list(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $document = $builder->build([$this->makeListEndpoint()]);
-
-        $responses = $document['paths']['/api/v1/stubs']['get']['responses'];
-
-        $this->assertArrayNotHasKey('404', $responses);
-    }
-
-    #[Test]
-    #[TestDox('it handles rules as pipe-delimited strings')]
-    public function it_handles_pipe_delimited_rules(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs',
-                httpMethods: ['POST'],
-                resourceClass: OpenApiStubResource::class,
-                isList: false,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'store',
-                formRequestClass: DocBuilderStubPipeRulesFormRequest::class,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $props = $document['paths']['/api/v1/stubs']['post']['requestBody']['content']['application/json']['schema']['properties'];
-
-        $this->assertSame('integer', $props['age']['type']);
-    }
-
-    #[Test]
-    #[TestDox('it generates list GET summary')]
-    public function it_generates_list_get_summary(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $document = $builder->build([$this->makeListEndpoint()]);
-
-        $this->assertSame('List Open Api Stubs', $document['paths']['/api/v1/stubs']['get']['summary']);
-    }
-
-    #[Test]
-    #[TestDox('it generates single GET summary')]
-    public function it_generates_single_get_summary(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs/{stub}',
-                httpMethods: ['GET'],
-                resourceClass: OpenApiStubResource::class,
-                isList: false,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'show',
-                formRequestClass: null,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $this->assertSame('Get Open Api Stub', $document['paths']['/api/v1/stubs/{stub}']['get']['summary']);
-    }
-
-    #[Test]
-    #[TestDox('it skips non-string rules in rulesToOpenApiType')]
-    public function it_skips_non_string_rules(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs',
-                httpMethods: ['POST'],
-                resourceClass: OpenApiStubResource::class,
-                isList: false,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'store',
-                formRequestClass: DocBuilderStubObjectRuleFormRequest::class,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $props = $document['paths']['/api/v1/stubs']['post']['requestBody']['content']['application/json']['schema']['properties'];
-        // Should still have string type (non-string rule objects are skipped)
-        $this->assertSame('string', $props['name']['type']);
-    }
-
-    #[Test]
-    #[TestDox('it generates default summary for unknown HTTP method')]
-    public function it_generates_default_summary(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs',
-                httpMethods: ['OPTIONS'],
-                resourceClass: OpenApiStubResource::class,
-                isList: false,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'options',
-                formRequestClass: null,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $this->assertSame('OPTIONS Open Api Stub', $document['paths']['/api/v1/stubs']['options']['summary']);
-    }
-
-    #[Test]
-    #[TestDox('it handles formRequest that throws on instantiation')]
-    public function it_handles_throwing_form_request(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs',
-                httpMethods: ['POST'],
-                resourceClass: OpenApiStubResource::class,
-                isList: false,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'store',
-                formRequestClass: DocBuilderStubThrowingFormRequest::class,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $this->assertArrayNotHasKey('requestBody', $document['paths']['/api/v1/stubs']['post']);
-    }
-
-    #[Test]
-    #[TestDox('it handles formRequest without rules method')]
-    public function it_handles_no_rules_method(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs',
-                httpMethods: ['POST'],
-                resourceClass: OpenApiStubResource::class,
-                isList: false,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'store',
-                formRequestClass: DocBuilderStubNoRulesMethodRequest::class,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $this->assertArrayNotHasKey('requestBody', $document['paths']['/api/v1/stubs']['post']);
-    }
-
-    #[Test]
-    #[TestDox('it generates POST summary')]
-    public function it_generates_post_summary(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs',
-                httpMethods: ['POST'],
-                resourceClass: OpenApiStubResource::class,
-                isList: false,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'store',
-                formRequestClass: null,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $this->assertSame('Create Open Api Stub', $document['paths']['/api/v1/stubs']['post']['summary']);
-    }
-
-    #[Test]
-    #[TestDox('it omits required array when no fields are required')]
-    public function it_omits_required_when_none(): void
-    {
-        $builder = new DocumentBuilder();
-
-        $endpoints = [
-            new EndpointDefinition(
-                path: '/api/v1/stubs',
-                httpMethods: ['POST'],
-                resourceClass: OpenApiStubResource::class,
-                isList: false,
-                controllerClass: 'App\Controllers\StubController',
-                methodName: 'store',
-                formRequestClass: DocBuilderStubOptionalFormRequest::class,
-                routeName: null,
-            ),
-        ];
-
-        $document = $builder->build($endpoints);
-
-        $schema = $document['paths']['/api/v1/stubs']['post']['requestBody']['content']['application/json']['schema'];
-        $this->assertArrayNotHasKey('required', $schema);
-    }
-
-    private function makeListEndpoint(): EndpointDefinition
-    {
-        return new EndpointDefinition(
+    return new EndpointDefinition(
+        path: '/api/v1/stubs',
+        httpMethods: ['GET'],
+        resourceClass: OpenApiStubResource::class,
+        isList: true,
+        controllerClass: 'App\Controllers\StubController',
+        methodName: 'index',
+        formRequestClass: null,
+        routeName: null,
+    );
+}
+
+it('builds a valid OpenAPI 3.1 document', function () {
+    $builder = new DocumentBuilder(
+        title: 'Test API',
+        version: '2.0.0',
+        description: 'A test API',
+    );
+
+    $endpoints = [
+        new EndpointDefinition(
+            path: '/api/v1/stubs',
+            httpMethods: ['GET'],
+            resourceClass: OpenApiStubResource::class,
+            isList: true,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'index',
+            formRequestClass: null,
+            routeName: 'api.v1.stubs.index',
+        ),
+        new EndpointDefinition(
+            path: '/api/v1/stubs/{stub}',
+            httpMethods: ['GET'],
+            resourceClass: OpenApiStubResource::class,
+            isList: false,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'show',
+            formRequestClass: null,
+            routeName: 'api.v1.stubs.show',
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    expect($document['openapi'])->toBe('3.1.0');
+    expect($document['info']['title'])->toBe('Test API');
+    expect($document['info']['version'])->toBe('2.0.0');
+    expect($document['info']['description'])->toBe('A test API');
+});
+
+it('generates paths for list endpoints', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        new EndpointDefinition(
             path: '/api/v1/stubs',
             httpMethods: ['GET'],
             resourceClass: OpenApiStubResource::class,
@@ -847,6 +83,659 @@ final class DocumentBuilderTest extends TestCase
             methodName: 'index',
             formRequestClass: null,
             routeName: null,
-        );
-    }
-}
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    expect($document['paths'])->toHaveKey('/api/v1/stubs');
+    expect($document['paths']['/api/v1/stubs'])->toHaveKey('get');
+    expect($document['paths']['/api/v1/stubs']['get'])->toHaveKey('parameters');
+});
+
+it('generates paths for single resource endpoints', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        new EndpointDefinition(
+            path: '/api/v1/stubs/{stub}',
+            httpMethods: ['GET'],
+            resourceClass: OpenApiStubResource::class,
+            isList: false,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'show',
+            formRequestClass: null,
+            routeName: null,
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    $path = $document['paths']['/api/v1/stubs/{stub}'];
+
+    expect($path)->toHaveKey('get');
+    expect($path)->toHaveKey('parameters');
+    expect($path['parameters'][0]['name'])->toBe('stub');
+    expect($path['parameters'][0]['in'])->toBe('path');
+});
+
+it('registers resource schemas in components', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        new EndpointDefinition(
+            path: '/api/v1/stubs',
+            httpMethods: ['GET'],
+            resourceClass: OpenApiStubResource::class,
+            isList: true,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'index',
+            formRequestClass: null,
+            routeName: null,
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    expect($document['components']['schemas'])->toHaveKey('OpenApiStub');
+    expect($document['components']['schemas'])->toHaveKey('OpenApiStubCollection');
+    expect($document['components']['schemas'])->toHaveKey('JsonApiError');
+});
+
+it('generates correct tags', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        new EndpointDefinition(
+            path: '/api/v1/stubs',
+            httpMethods: ['GET'],
+            resourceClass: OpenApiStubResource::class,
+            isList: true,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'index',
+            formRequestClass: null,
+            routeName: null,
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    expect($document['paths']['/api/v1/stubs']['get']['tags'])->toBe(['Open Api Stubs']);
+});
+
+it('handles POST endpoints with 201 status', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        new EndpointDefinition(
+            path: '/api/v1/stubs',
+            httpMethods: ['POST'],
+            resourceClass: OpenApiStubResource::class,
+            isList: false,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'store',
+            formRequestClass: null,
+            routeName: null,
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    $responses = $document['paths']['/api/v1/stubs']['post']['responses'];
+
+    expect($responses)->toHaveKey('201');
+    expect($responses)->toHaveKey('422');
+});
+
+it('handles DELETE endpoints with 204 status', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        new EndpointDefinition(
+            path: '/api/v1/stubs/{stub}',
+            httpMethods: ['DELETE'],
+            resourceClass: OpenApiStubResource::class,
+            isList: false,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'destroy',
+            formRequestClass: null,
+            routeName: null,
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    $responses = $document['paths']['/api/v1/stubs/{stub}']['delete']['responses'];
+
+    expect($responses)->toHaveKey('204');
+});
+
+it('omits description when empty', function () {
+    $builder = new DocumentBuilder(title: 'API', version: '1.0.0', description: '');
+
+    $document = $builder->build([makeListEndpoint()]);
+
+    expect($document['info'])->not->toHaveKey('description');
+});
+
+it('omits servers when empty', function () {
+    $builder = new DocumentBuilder(servers: []);
+
+    $document = $builder->build([makeListEndpoint()]);
+
+    expect($document)->not->toHaveKey('servers');
+});
+
+it('omits security when empty', function () {
+    $builder = new DocumentBuilder(security: []);
+
+    $document = $builder->build([makeListEndpoint()]);
+
+    expect($document)->not->toHaveKey('security');
+});
+
+it('omits securitySchemes when empty', function () {
+    $builder = new DocumentBuilder(securitySchemes: []);
+
+    $document = $builder->build([makeListEndpoint()]);
+
+    expect($document['components'])->not->toHaveKey('securitySchemes');
+});
+
+it('does not duplicate tags for same resource', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        makeListEndpoint(),
+        new EndpointDefinition(
+            path: '/api/v1/stubs/{stub}',
+            httpMethods: ['GET'],
+            resourceClass: OpenApiStubResource::class,
+            isList: false,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'show',
+            formRequestClass: null,
+            routeName: null,
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    $tagNames = array_column($document['tags'], 'name');
+    expect($tagNames)->toHaveCount(1);
+    expect($tagNames[0])->toBe('Open Api Stubs');
+});
+
+it('omits operationId when route has no name', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        new EndpointDefinition(
+            path: '/api/v1/stubs',
+            httpMethods: ['GET'],
+            resourceClass: OpenApiStubResource::class,
+            isList: true,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'index',
+            formRequestClass: null,
+            routeName: null,
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    expect($document['paths']['/api/v1/stubs']['get'])->not->toHaveKey('operationId');
+});
+
+it('generates PUT/PATCH summary', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        new EndpointDefinition(
+            path: '/api/v1/stubs/{stub}',
+            httpMethods: ['PUT', 'PATCH'],
+            resourceClass: OpenApiStubResource::class,
+            isList: false,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'update',
+            formRequestClass: null,
+            routeName: null,
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    expect($document['paths']['/api/v1/stubs/{stub}']['put']['summary'])->toBe('Update Open Api Stub');
+    expect($document['paths']['/api/v1/stubs/{stub}']['patch']['summary'])->toBe('Update Open Api Stub');
+});
+
+it('generates DELETE summary', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        new EndpointDefinition(
+            path: '/api/v1/stubs/{stub}',
+            httpMethods: ['DELETE'],
+            resourceClass: OpenApiStubResource::class,
+            isList: false,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'destroy',
+            formRequestClass: null,
+            routeName: null,
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    expect($document['paths']['/api/v1/stubs/{stub}']['delete']['summary'])->toBe('Delete Open Api Stub');
+});
+
+it('converts optional path parameters', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        new EndpointDefinition(
+            path: '/api/v1/stubs/{stub?}',
+            httpMethods: ['GET'],
+            resourceClass: OpenApiStubResource::class,
+            isList: false,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'show',
+            formRequestClass: null,
+            routeName: null,
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    expect($document['paths'])->toHaveKey('/api/v1/stubs/{stub}');
+});
+
+it('generates path parameter description matching resource name', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        new EndpointDefinition(
+            path: '/api/v1/stubs/{stub}',
+            httpMethods: ['GET'],
+            resourceClass: OpenApiStubResource::class,
+            isList: false,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'show',
+            formRequestClass: null,
+            routeName: null,
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    $params = $document['paths']['/api/v1/stubs/{stub}']['parameters'];
+    expect($params[0])->toHaveKey('description');
+});
+
+it('generates non-matching path parameter description', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        new EndpointDefinition(
+            path: '/api/v1/stubs/{category_id}',
+            httpMethods: ['GET'],
+            resourceClass: OpenApiStubResource::class,
+            isList: false,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'show',
+            formRequestClass: null,
+            routeName: null,
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    $params = $document['paths']['/api/v1/stubs/{category_id}']['parameters'];
+    expect($params[0]['description'])->toContain('Category Id');
+});
+
+it('builds request body from form request rules', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        new EndpointDefinition(
+            path: '/api/v1/stubs',
+            httpMethods: ['POST'],
+            resourceClass: OpenApiStubResource::class,
+            isList: false,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'store',
+            formRequestClass: DocBuilderStubFormRequest::class,
+            routeName: null,
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    $requestBody = $document['paths']['/api/v1/stubs']['post']['requestBody'];
+
+    expect($requestBody['required'])->toBeTrue();
+    $schema = $requestBody['content']['application/json']['schema'];
+    expect($schema['type'])->toBe('object');
+    expect($schema['properties'])->toHaveKey('name');
+    expect($schema['properties'])->toHaveKey('email');
+    expect($schema['required'])->toContain('name');
+});
+
+it('maps form rules to OpenAPI types', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        new EndpointDefinition(
+            path: '/api/v1/stubs',
+            httpMethods: ['POST'],
+            resourceClass: OpenApiStubResource::class,
+            isList: false,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'store',
+            formRequestClass: DocBuilderStubTypedFormRequest::class,
+            routeName: null,
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    $schema = $document['paths']['/api/v1/stubs']['post']['requestBody']['content']['application/json']['schema'];
+    $props = $schema['properties'];
+
+    expect($props['age']['type'])->toBe('integer');
+    expect($props['active']['type'])->toBe('boolean');
+    expect($props['email']['type'])->toBe('string');
+    expect($props['email']['format'])->toBe('email');
+    expect($props['website']['type'])->toBe('string');
+    expect($props['website']['format'])->toBe('uri');
+    expect($props['birthday']['type'])->toBe('string');
+    expect($props['birthday']['format'])->toBe('date');
+    expect($props['tags']['type'])->toBe('array');
+    expect($props['description']['nullable'])->toBeTrue();
+});
+
+it('maps min and max rules to schema constraints', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        new EndpointDefinition(
+            path: '/api/v1/stubs',
+            httpMethods: ['POST'],
+            resourceClass: OpenApiStubResource::class,
+            isList: false,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'store',
+            formRequestClass: DocBuilderStubMinMaxFormRequest::class,
+            routeName: null,
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    $props = $document['paths']['/api/v1/stubs']['post']['requestBody']['content']['application/json']['schema']['properties'];
+
+    expect($props['name']['minLength'])->toBe(3);
+    expect($props['name']['maxLength'])->toBe(255);
+});
+
+it('skips nested dot-notation rules in request body', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        new EndpointDefinition(
+            path: '/api/v1/stubs',
+            httpMethods: ['POST'],
+            resourceClass: OpenApiStubResource::class,
+            isList: false,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'store',
+            formRequestClass: DocBuilderStubNestedFormRequest::class,
+            routeName: null,
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    $props = $document['paths']['/api/v1/stubs']['post']['requestBody']['content']['application/json']['schema']['properties'];
+
+    expect($props)->toHaveKey('items');
+    expect($props)->not->toHaveKey('items.name');
+});
+
+it('omits request body when form request has no rules', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        new EndpointDefinition(
+            path: '/api/v1/stubs',
+            httpMethods: ['POST'],
+            resourceClass: OpenApiStubResource::class,
+            isList: false,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'store',
+            formRequestClass: DocBuilderStubEmptyFormRequest::class,
+            routeName: null,
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    expect($document['paths']['/api/v1/stubs']['post'])->not->toHaveKey('requestBody');
+});
+
+it('includes 422 for PUT/PATCH endpoints', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        new EndpointDefinition(
+            path: '/api/v1/stubs/{stub}',
+            httpMethods: ['PUT'],
+            resourceClass: OpenApiStubResource::class,
+            isList: false,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'update',
+            formRequestClass: null,
+            routeName: null,
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    $responses = $document['paths']['/api/v1/stubs/{stub}']['put']['responses'];
+
+    expect($responses)->toHaveKey('422');
+    expect($responses)->toHaveKey('401');
+    expect($responses)->toHaveKey('404');
+});
+
+it('does not include 404 response for list endpoints', function () {
+    $builder = new DocumentBuilder();
+
+    $document = $builder->build([makeListEndpoint()]);
+
+    $responses = $document['paths']['/api/v1/stubs']['get']['responses'];
+
+    expect($responses)->not->toHaveKey('404');
+});
+
+it('handles rules as pipe-delimited strings', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        new EndpointDefinition(
+            path: '/api/v1/stubs',
+            httpMethods: ['POST'],
+            resourceClass: OpenApiStubResource::class,
+            isList: false,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'store',
+            formRequestClass: DocBuilderStubPipeRulesFormRequest::class,
+            routeName: null,
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    $props = $document['paths']['/api/v1/stubs']['post']['requestBody']['content']['application/json']['schema']['properties'];
+
+    expect($props['age']['type'])->toBe('integer');
+});
+
+it('generates list GET summary', function () {
+    $builder = new DocumentBuilder();
+
+    $document = $builder->build([makeListEndpoint()]);
+
+    expect($document['paths']['/api/v1/stubs']['get']['summary'])->toBe('List Open Api Stubs');
+});
+
+it('generates single GET summary', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        new EndpointDefinition(
+            path: '/api/v1/stubs/{stub}',
+            httpMethods: ['GET'],
+            resourceClass: OpenApiStubResource::class,
+            isList: false,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'show',
+            formRequestClass: null,
+            routeName: null,
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    expect($document['paths']['/api/v1/stubs/{stub}']['get']['summary'])->toBe('Get Open Api Stub');
+});
+
+it('skips non-string rules in rulesToOpenApiType', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        new EndpointDefinition(
+            path: '/api/v1/stubs',
+            httpMethods: ['POST'],
+            resourceClass: OpenApiStubResource::class,
+            isList: false,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'store',
+            formRequestClass: DocBuilderStubObjectRuleFormRequest::class,
+            routeName: null,
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    $props = $document['paths']['/api/v1/stubs']['post']['requestBody']['content']['application/json']['schema']['properties'];
+    expect($props['name']['type'])->toBe('string');
+});
+
+it('generates default summary for unknown HTTP method', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        new EndpointDefinition(
+            path: '/api/v1/stubs',
+            httpMethods: ['OPTIONS'],
+            resourceClass: OpenApiStubResource::class,
+            isList: false,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'options',
+            formRequestClass: null,
+            routeName: null,
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    expect($document['paths']['/api/v1/stubs']['options']['summary'])->toBe('OPTIONS Open Api Stub');
+});
+
+it('handles formRequest that throws on instantiation', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        new EndpointDefinition(
+            path: '/api/v1/stubs',
+            httpMethods: ['POST'],
+            resourceClass: OpenApiStubResource::class,
+            isList: false,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'store',
+            formRequestClass: DocBuilderStubThrowingFormRequest::class,
+            routeName: null,
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    expect($document['paths']['/api/v1/stubs']['post'])->not->toHaveKey('requestBody');
+});
+
+it('handles formRequest without rules method', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        new EndpointDefinition(
+            path: '/api/v1/stubs',
+            httpMethods: ['POST'],
+            resourceClass: OpenApiStubResource::class,
+            isList: false,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'store',
+            formRequestClass: DocBuilderStubNoRulesMethodRequest::class,
+            routeName: null,
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    expect($document['paths']['/api/v1/stubs']['post'])->not->toHaveKey('requestBody');
+});
+
+it('generates POST summary', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        new EndpointDefinition(
+            path: '/api/v1/stubs',
+            httpMethods: ['POST'],
+            resourceClass: OpenApiStubResource::class,
+            isList: false,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'store',
+            formRequestClass: null,
+            routeName: null,
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    expect($document['paths']['/api/v1/stubs']['post']['summary'])->toBe('Create Open Api Stub');
+});
+
+it('omits required array when no fields are required', function () {
+    $builder = new DocumentBuilder();
+
+    $endpoints = [
+        new EndpointDefinition(
+            path: '/api/v1/stubs',
+            httpMethods: ['POST'],
+            resourceClass: OpenApiStubResource::class,
+            isList: false,
+            controllerClass: 'App\Controllers\StubController',
+            methodName: 'store',
+            formRequestClass: DocBuilderStubOptionalFormRequest::class,
+            routeName: null,
+        ),
+    ];
+
+    $document = $builder->build($endpoints);
+
+    $schema = $document['paths']['/api/v1/stubs']['post']['requestBody']['content']['application/json']['schema'];
+    expect($schema)->not->toHaveKey('required');
+});

--- a/tests/Feature/OpenApi/RouteScannerTest.php
+++ b/tests/Feature/OpenApi/RouteScannerTest.php
@@ -14,223 +14,167 @@ use BlueBeetle\ApiToolkit\Tests\Fixtures\Controllers\ScannerStubNoResourceContro
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Controllers\ScannerStubShowController;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Requests\ScannerStubCreateRequest;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Resources\ProductResource;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
 use Illuminate\Support\Facades\Route;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
 
-final class RouteScannerTest extends TestCase
-{
-    #[Test]
-    #[TestDox('it scans routes with resource usage')]
-    public function it_scans_routes(): void
-    {
-        Route::get('/api/v1/products', [ScannerStubListController::class, '__invoke'])
-            ->name('api.v1.products.index')
-        ;
+it('scans routes with resource usage', function () {
+    Route::get('/api/v1/products', [ScannerStubListController::class, '__invoke'])
+        ->name('api.v1.products.index')
+    ;
 
-        $scanner = app(RouteScanner::class);
-        $endpoints = $scanner->scan();
+    $scanner = app(RouteScanner::class);
+    $endpoints = $scanner->scan();
 
-        $this->assertNotEmpty($endpoints);
-        $this->assertSame('/api/v1/products', $endpoints[0]->path);
-        $this->assertSame(ProductResource::class, $endpoints[0]->resourceClass);
-        $this->assertTrue($endpoints[0]->isList);
-        $this->assertSame('api.v1.products.index', $endpoints[0]->routeName);
-    }
+    expect($endpoints)->not->toBeEmpty();
+    expect($endpoints[0]->path)->toBe('/api/v1/products');
+    expect($endpoints[0]->resourceClass)->toBe(ProductResource::class);
+    expect($endpoints[0]->isList)->toBeTrue();
+    expect($endpoints[0]->routeName)->toBe('api.v1.products.index');
+});
 
-    #[Test]
-    #[TestDox('it ignores closure routes')]
-    public function it_ignores_closure_routes(): void
-    {
-        Route::get('/api/v1/health', fn () => response()->json(['ok' => true]));
+it('ignores closure routes', function () {
+    Route::get('/api/v1/health', fn () => response()->json(['ok' => true]));
 
-        $scanner = app(RouteScanner::class);
-        $endpoints = $scanner->scan();
+    $scanner = app(RouteScanner::class);
+    $endpoints = $scanner->scan();
 
-        $endpointPaths = array_map(fn ($e) => $e->path, $endpoints);
-        $this->assertNotContains('/api/v1/health', $endpointPaths);
-    }
+    $endpointPaths = array_map(fn ($e) => $e->path, $endpoints);
+    expect($endpointPaths)->not->toContain('/api/v1/health');
+});
 
-    #[Test]
-    #[TestDox('it ignores routes without resource class')]
-    public function it_ignores_routes_without_resource(): void
-    {
-        Route::get('/api/v1/health', [ScannerStubNoResourceController::class, '__invoke']);
+it('ignores routes without resource class', function () {
+    Route::get('/api/v1/health', [ScannerStubNoResourceController::class, '__invoke']);
 
-        $scanner = app(RouteScanner::class);
-        $endpoints = $scanner->scan();
+    $scanner = app(RouteScanner::class);
+    $endpoints = $scanner->scan();
 
-        $endpointPaths = array_map(fn ($e) => $e->path, $endpoints);
-        $this->assertNotContains('/api/v1/health', $endpointPaths);
-    }
+    $endpointPaths = array_map(fn ($e) => $e->path, $endpoints);
+    expect($endpointPaths)->not->toContain('/api/v1/health');
+});
 
-    #[Test]
-    #[TestDox('it detects single resource endpoints')]
-    public function it_detects_single_endpoints(): void
-    {
-        Route::get('/api/v1/products/{product}', [ScannerStubShowController::class, '__invoke']);
+it('detects single resource endpoints', function () {
+    Route::get('/api/v1/products/{product}', [ScannerStubShowController::class, '__invoke']);
 
-        $scanner = app(RouteScanner::class);
-        $endpoints = $scanner->scan();
+    $scanner = app(RouteScanner::class);
+    $endpoints = $scanner->scan();
 
-        $productEndpoint = collect($endpoints)->firstWhere('path', '/api/v1/products/{product}');
+    $productEndpoint = collect($endpoints)->firstWhere('path', '/api/v1/products/{product}');
 
-        $this->assertNotNull($productEndpoint);
-        $this->assertFalse($productEndpoint->isList);
-    }
+    expect($productEndpoint)->not->toBeNull();
+    expect($productEndpoint->isList)->toBeFalse();
+});
 
-    #[Test]
-    #[TestDox('it detects form request class from type hints')]
-    public function it_detects_form_request(): void
-    {
-        Route::post('/api/v1/products', [ScannerStubCreateController::class, '__invoke']);
+it('detects form request class from type hints', function () {
+    Route::post('/api/v1/products', [ScannerStubCreateController::class, '__invoke']);
 
-        $scanner = app(RouteScanner::class);
-        $endpoints = $scanner->scan();
+    $scanner = app(RouteScanner::class);
+    $endpoints = $scanner->scan();
 
-        $createEndpoint = collect($endpoints)->firstWhere('path', '/api/v1/products');
+    $createEndpoint = collect($endpoints)->firstWhere('path', '/api/v1/products');
 
-        $this->assertNotNull($createEndpoint);
-        $this->assertSame(ScannerStubCreateRequest::class, $createEndpoint->formRequestClass);
-    }
+    expect($createEndpoint)->not->toBeNull();
+    expect($createEndpoint->formRequestClass)->toBe(ScannerStubCreateRequest::class);
+});
 
-    #[Test]
-    #[TestDox('it returns null form request when none type-hinted')]
-    public function it_returns_null_form_request(): void
-    {
-        Route::get('/api/v1/products', [ScannerStubListController::class, '__invoke']);
+it('returns null form request when none type-hinted', function () {
+    Route::get('/api/v1/products', [ScannerStubListController::class, '__invoke']);
 
-        $scanner = app(RouteScanner::class);
-        $endpoints = $scanner->scan();
+    $scanner = app(RouteScanner::class);
+    $endpoints = $scanner->scan();
 
-        $this->assertNull($endpoints[0]->formRequestClass);
-    }
+    expect($endpoints[0]->formRequestClass)->toBeNull();
+});
 
-    #[Test]
-    #[TestDox('it extracts HTTP methods excluding HEAD')]
-    public function it_excludes_head_method(): void
-    {
-        Route::get('/api/v1/products', [ScannerStubListController::class, '__invoke']);
+it('extracts HTTP methods excluding HEAD', function () {
+    Route::get('/api/v1/products', [ScannerStubListController::class, '__invoke']);
 
-        $scanner = app(RouteScanner::class);
-        $endpoints = $scanner->scan();
+    $scanner = app(RouteScanner::class);
+    $endpoints = $scanner->scan();
 
-        $this->assertContains('GET', $endpoints[0]->httpMethods);
-        $this->assertNotContains('HEAD', $endpoints[0]->httpMethods);
-    }
+    expect($endpoints[0]->httpMethods)->toContain('GET');
+    expect($endpoints[0]->httpMethods)->not->toContain('HEAD');
+});
 
-    #[Test]
-    #[TestDox('it returns empty array when no toolkit routes exist')]
-    public function it_returns_empty_for_no_routes(): void
-    {
-        $scanner = app(RouteScanner::class);
-        $endpoints = $scanner->scan();
+it('returns empty array when no toolkit routes exist', function () {
+    $scanner = app(RouteScanner::class);
+    $endpoints = $scanner->scan();
 
-        $this->assertSame([], $endpoints);
-    }
+    expect($endpoints)->toBe([]);
+});
 
-    #[Test]
-    #[TestDox('it detects cursorPaginate as list endpoint')]
-    public function it_detects_cursor_paginate(): void
-    {
-        Route::get('/api/v1/products', [ScannerStubCursorController::class, '__invoke']);
+it('detects cursorPaginate as list endpoint', function () {
+    Route::get('/api/v1/products', [ScannerStubCursorController::class, '__invoke']);
 
-        $scanner = app(RouteScanner::class);
-        $endpoints = $scanner->scan();
+    $scanner = app(RouteScanner::class);
+    $endpoints = $scanner->scan();
 
-        $this->assertTrue($endpoints[0]->isList);
-    }
+    expect($endpoints[0]->isList)->toBeTrue();
+});
 
-    #[Test]
-    #[TestDox('it resolves controller class and method name')]
-    public function it_resolves_controller_info(): void
-    {
-        Route::get('/api/v1/products', [ScannerStubListController::class, '__invoke']);
+it('resolves controller class and method name', function () {
+    Route::get('/api/v1/products', [ScannerStubListController::class, '__invoke']);
 
-        $scanner = app(RouteScanner::class);
-        $endpoints = $scanner->scan();
+    $scanner = app(RouteScanner::class);
+    $endpoints = $scanner->scan();
 
-        $this->assertSame(ScannerStubListController::class, $endpoints[0]->controllerClass);
-        $this->assertSame('__invoke', $endpoints[0]->methodName);
-    }
+    expect($endpoints[0]->controllerClass)->toBe(ScannerStubListController::class);
+    expect($endpoints[0]->methodName)->toBe('__invoke');
+});
 
-    #[Test]
-    #[TestDox('it handles controller@method format')]
-    public function it_handles_at_method_format(): void
-    {
-        Route::get('/api/v1/products', ScannerStubAtMethodController::class.'@index');
+it('handles controller@method format', function () {
+    Route::get('/api/v1/products', ScannerStubAtMethodController::class.'@index');
 
-        $scanner = app(RouteScanner::class);
-        $endpoints = $scanner->scan();
+    $scanner = app(RouteScanner::class);
+    $endpoints = $scanner->scan();
 
-        $this->assertNotEmpty($endpoints);
-        $this->assertSame('index', $endpoints[0]->methodName);
-    }
+    expect($endpoints)->not->toBeEmpty();
+    expect($endpoints[0]->methodName)->toBe('index');
+});
 
-    #[Test]
-    #[TestDox('it skips parameters with builtin types')]
-    public function it_skips_builtin_type_params(): void
-    {
-        Route::get('/api/v1/products', [ScannerStubBuiltinParamController::class, '__invoke']);
+it('skips parameters with builtin types', function () {
+    Route::get('/api/v1/products', [ScannerStubBuiltinParamController::class, '__invoke']);
 
-        $scanner = app(RouteScanner::class);
-        $endpoints = $scanner->scan();
+    $scanner = app(RouteScanner::class);
+    $endpoints = $scanner->scan();
 
-        $this->assertNotEmpty($endpoints);
-        $this->assertNull($endpoints[0]->formRequestClass);
-    }
+    expect($endpoints)->not->toBeEmpty();
+    expect($endpoints[0]->formRequestClass)->toBeNull();
+});
 
-    #[Test]
-    #[TestDox('it handles invokable controller string format')]
-    public function it_handles_invokable_string_format(): void
-    {
-        Route::get('/api/v1/products', ScannerStubListController::class);
+it('handles invokable controller string format', function () {
+    Route::get('/api/v1/products', ScannerStubListController::class);
 
-        $scanner = app(RouteScanner::class);
-        $endpoints = $scanner->scan();
+    $scanner = app(RouteScanner::class);
+    $endpoints = $scanner->scan();
 
-        $this->assertNotEmpty($endpoints);
-        $this->assertSame('__invoke', $endpoints[0]->methodName);
-    }
+    expect($endpoints)->not->toBeEmpty();
+    expect($endpoints[0]->methodName)->toBe('__invoke');
+});
 
-    #[Test]
-    #[TestDox('it ignores non-existent controller classes')]
-    public function it_ignores_non_existent_controllers(): void
-    {
-        Route::get('/api/v1/fake', 'App\NonExistent\FakeController@index');
+it('ignores non-existent controller classes', function () {
+    Route::get('/api/v1/fake', 'App\NonExistent\FakeController@index');
 
-        $scanner = app(RouteScanner::class);
-        $endpoints = $scanner->scan();
+    $scanner = app(RouteScanner::class);
+    $endpoints = $scanner->scan();
 
-        $endpointPaths = array_map(fn ($e) => $e->path, $endpoints);
-        $this->assertNotContains('/api/v1/fake', $endpointPaths);
-    }
+    $endpointPaths = array_map(fn ($e) => $e->path, $endpoints);
+    expect($endpointPaths)->not->toContain('/api/v1/fake');
+});
 
-    #[Test]
-    #[TestDox('it ignores controllers where method does not exist')]
-    public function it_ignores_missing_methods(): void
-    {
-        Route::get('/api/v1/products', ScannerStubListController::class.'@nonExistentMethod');
+it('ignores controllers where method does not exist', function () {
+    Route::get('/api/v1/products', ScannerStubListController::class.'@nonExistentMethod');
 
-        $scanner = app(RouteScanner::class);
-        $endpoints = $scanner->scan();
+    $scanner = app(RouteScanner::class);
+    $endpoints = $scanner->scan();
 
-        $this->assertEmpty($endpoints);
-    }
+    expect($endpoints)->toBeEmpty();
+});
 
-    #[Test]
-    #[TestDox('it resolves resource class from same namespace when no use statement')]
-    public function it_resolves_same_namespace(): void
-    {
-        // The existing controllers use `use` imports, so this is already covered
-        // This test ensures the full scanning pipeline works
-        Route::get('/api/v1/products', [ScannerStubListController::class, '__invoke']);
+it('resolves resource class from same namespace when no use statement', function () {
+    Route::get('/api/v1/products', [ScannerStubListController::class, '__invoke']);
 
-        $scanner = app(RouteScanner::class);
-        $endpoints = $scanner->scan();
+    $scanner = app(RouteScanner::class);
+    $endpoints = $scanner->scan();
 
-        $this->assertNotEmpty($endpoints);
-        $this->assertSame(ProductResource::class, $endpoints[0]->resourceClass);
-    }
-}
+    expect($endpoints)->not->toBeEmpty();
+    expect($endpoints[0]->resourceClass)->toBe(ProductResource::class);
+});

--- a/tests/Feature/OpenApi/SchemaBuilderTest.php
+++ b/tests/Feature/OpenApi/SchemaBuilderTest.php
@@ -22,353 +22,269 @@ use BlueBeetle\ApiToolkit\Tests\Fixtures\Resources\OpenApiStubWithNoCastModelRes
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Resources\OpenApiStubWithRelationshipsResource;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Resources\OpenApiStubWithSchemaResource;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Resources\OpenApiStubWithSortsOnlyResource;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
-
-final class SchemaBuilderTest extends TestCase
-{
-    #[Test]
-    #[TestDox('it builds a resource schema with type and id')]
-    public function it_builds_resource_schema(): void
-    {
-        $builder = new SchemaBuilder();
-        $schema = $builder->buildResourceSchema(OpenApiStubResource::class);
-
-        $this->assertSame('object', $schema['type']);
-        $this->assertContains('type', $schema['required']);
-        $this->assertContains('id', $schema['required']);
-        $this->assertContains('attributes', $schema['required']);
-        $this->assertSame('string', $schema['properties']['type']['type']);
-        $this->assertSame('stubs', $schema['properties']['type']['example']);
-    }
-
-    #[Test]
-    #[TestDox('it builds attributes from schema method')]
-    public function it_builds_attributes_from_schema(): void
-    {
-        $builder = new SchemaBuilder();
-        $schema = $builder->buildResourceSchema(OpenApiStubWithSchemaResource::class);
-
-        $attributes = $schema['properties']['attributes'];
-
-        $this->assertSame('string', $attributes['properties']['name']['type']);
-        $this->assertSame('integer', $attributes['properties']['quantity']['type']);
-        $this->assertSame('boolean', $attributes['properties']['active']['type']);
-    }
-
-    #[Test]
-    #[TestDox('it builds relationships schema')]
-    public function it_builds_relationships_schema(): void
-    {
-        $builder = new SchemaBuilder();
-        $schema = $builder->buildResourceSchema(OpenApiStubWithRelationshipsResource::class);
-
-        $relationships = $schema['properties']['relationships'];
-
-        $this->assertArrayHasKey('category', $relationships['properties']);
-        $this->assertSame('categories', $relationships['properties']['category']['properties']['data']['oneOf'][0]['properties']['type']['example']);
-    }
-
-    #[Test]
-    #[TestDox('it builds query parameters from resource')]
-    public function it_builds_query_parameters(): void
-    {
-        $builder = new SchemaBuilder();
-        $params = $builder->buildQueryParameters(OpenApiStubWithFiltersResource::class);
-
-        $paramNames = array_column($params, 'name');
-
-        $this->assertContains('filter[name]', $paramNames);
-        $this->assertContains('filter[status]', $paramNames);
-        $this->assertContains('sort', $paramNames);
-        $this->assertContains('include', $paramNames);
-        $this->assertContains('page[number]', $paramNames);
-        $this->assertContains('page[size]', $paramNames);
-        $this->assertContains('page[cursor]', $paramNames);
-    }
-
-    #[Test]
-    #[TestDox('it builds collection schema')]
-    public function it_builds_collection_schema(): void
-    {
-        $builder = new SchemaBuilder();
-        $schema = $builder->buildCollectionSchema(OpenApiStubResource::class);
-
-        $this->assertSame('array', $schema['properties']['data']['type']);
-        $this->assertSame('#/components/schemas/OpenApiStub', $schema['properties']['data']['items']['$ref']);
-        $this->assertArrayHasKey('meta', $schema['properties']);
-        $this->assertArrayHasKey('links', $schema['properties']);
-    }
-
-    #[Test]
-    #[TestDox('it builds single resource response schema')]
-    public function it_builds_single_schema(): void
-    {
-        $builder = new SchemaBuilder();
-        $schema = $builder->buildSingleSchema(OpenApiStubResource::class);
-
-        $this->assertSame('#/components/schemas/OpenApiStub', $schema['properties']['data']['$ref']);
-    }
-
-    #[Test]
-    #[TestDox('it builds error schema')]
-    public function it_builds_error_schema(): void
-    {
-        $builder = new SchemaBuilder();
-        $schema = $builder->buildErrorSchema();
-
-        $this->assertSame('array', $schema['properties']['errors']['type']);
-        $this->assertArrayHasKey('status', $schema['properties']['errors']['items']['properties']);
-        $this->assertArrayHasKey('title', $schema['properties']['errors']['items']['properties']);
-        $this->assertArrayHasKey('detail', $schema['properties']['errors']['items']['properties']);
-    }
-
-    #[Test]
-    #[TestDox('it generates schema name from resource class')]
-    public function it_generates_schema_name(): void
-    {
-        $builder = new SchemaBuilder();
-
-        $this->assertSame('OpenApiStub', $builder->schemaName(OpenApiStubResource::class));
-        $this->assertSame('OpenApiStubWithSchema', $builder->schemaName(OpenApiStubWithSchemaResource::class));
-    }
-
-    #[Test]
-    #[TestDox('it falls back to additionalProperties when no schema and no model')]
-    public function it_falls_back_without_schema_or_model(): void
-    {
-        $builder = new SchemaBuilder();
-        $resource = app(OpenApiStubResource::class);
-
-        $attributes = $builder->buildAttributesSchema($resource);
-
-        $this->assertSame('object', $attributes['type']);
-        $this->assertTrue($attributes['additionalProperties']);
-    }
-
-    #[Test]
-    #[TestDox('it infers attributes schema from model casts')]
-    public function it_infers_from_model_casts(): void
-    {
-        $builder = new SchemaBuilder();
-        $resource = app(OpenApiStubWithModelResource::class);
-
-        $attributes = $builder->buildAttributesSchema($resource);
-
-        $this->assertSame('object', $attributes['type']);
-        $this->assertSame('integer', $attributes['properties']['price_in_cents']['type']);
-        $this->assertSame('boolean', $attributes['properties']['featured']['type']);
-    }
-
-    #[Test]
-    #[TestDox('it returns empty relationships schema when none defined')]
-    public function it_returns_empty_relationships(): void
-    {
-        $builder = new SchemaBuilder();
-        $resource = app(OpenApiStubResource::class);
-
-        $relationships = $builder->buildRelationshipsSchema($resource);
-
-        $this->assertSame('object', $relationships['type']);
-        $this->assertArrayNotHasKey('properties', $relationships);
-    }
-
-    #[Test]
-    #[TestDox('it builds query parameters without sorts or includes')]
-    public function it_builds_params_without_sorts_or_includes(): void
-    {
-        $builder = new SchemaBuilder();
-        $params = $builder->buildQueryParameters(OpenApiStubResource::class);
-
-        $paramNames = array_column($params, 'name');
-
-        // Should still have pagination params
-        $this->assertContains('page[number]', $paramNames);
-        $this->assertContains('page[size]', $paramNames);
-        $this->assertContains('page[cursor]', $paramNames);
-
-        // Should not have sort or include params
-        $this->assertNotContains('sort', $paramNames);
-        $this->assertNotContains('include', $paramNames);
-    }
-
-    #[Test]
-    #[TestDox('it resolves DateFilter type')]
-    public function it_resolves_date_filter_type(): void
-    {
-        $builder = new SchemaBuilder();
-        $params = $builder->buildQueryParameters(OpenApiStubWithDateFilterResource::class);
-
-        $dateParam = collect($params)->firstWhere('name', 'filter[created_at]');
-
-        $this->assertSame('date', $dateParam['schema']['format']);
-        $this->assertSame('string', $dateParam['schema']['type']);
-    }
-
-    #[Test]
-    #[TestDox('it resolves filter type from class string')]
-    public function it_resolves_filter_from_class_string(): void
-    {
-        $builder = new SchemaBuilder();
-        $params = $builder->buildQueryParameters(OpenApiStubWithClassStringFilterResource::class);
-
-        $paramNames = array_column($params, 'name');
-        $this->assertContains('filter[status]', $paramNames);
-    }
-
-    #[Test]
-    #[TestDox('it normalizes schema with array definitions')]
-    public function it_normalizes_array_definitions(): void
-    {
-        $builder = new SchemaBuilder();
-        $schema = $builder->buildResourceSchema(OpenApiStubWithMixedSchemaResource::class);
-
-        $attributes = $schema['properties']['attributes'];
-
-        // String shorthand
-        $this->assertSame('string', $attributes['properties']['name']['type']);
-        // Array definition passed through
-        $this->assertSame('string', $attributes['properties']['description']['type']);
-        $this->assertTrue($attributes['properties']['description']['nullable']);
-    }
-
-    #[Test]
-    #[TestDox('it maps all type shorthands to OpenAPI types')]
-    public function it_maps_type_shorthands(): void
-    {
-        $builder = new SchemaBuilder();
-        $schema = $builder->buildResourceSchema(OpenApiStubWithAllTypesResource::class);
-
-        $props = $schema['properties']['attributes']['properties'];
-
-        $this->assertSame('string', $props['name']['type']);
-        $this->assertSame('integer', $props['count']['type']);
-        $this->assertSame('number', $props['price']['type']);
-        $this->assertSame('boolean', $props['active']['type']);
-        $this->assertSame('array', $props['tags']['type']);
-        $this->assertSame('object', $props['metadata']['type']);
-        $this->assertSame('date', $props['birthday']['format']);
-        $this->assertSame('date-time', $props['created_at']['format']);
-    }
-
-    #[Test]
-    #[TestDox('it handles sort parameter without default sort')]
-    public function it_handles_sort_without_default(): void
-    {
-        $builder = new SchemaBuilder();
-        $params = $builder->buildQueryParameters(OpenApiStubWithSortsOnlyResource::class);
-
-        $sortParam = collect($params)->firstWhere('name', 'sort');
-
-        // When no default sort, uses first allowed sort as example
-        $this->assertSame('name', $sortParam['schema']['example']);
-        $this->assertStringContainsString('name, created_at', $sortParam['description']);
-    }
-
-    #[Test]
-    #[TestDox('it infers enum cast from model')]
-    public function it_infers_enum_cast(): void
-    {
-        $builder = new SchemaBuilder();
-        $resource = app(OpenApiStubWithEnumModelResource::class);
-
-        $attributes = $builder->buildAttributesSchema($resource);
-
-        // The model has enum casts, should be detected
-        $this->assertSame('object', $attributes['type']);
-    }
-
-    #[Test]
-    #[TestDox('it falls back when model has no casts')]
-    public function it_falls_back_with_empty_model_casts(): void
-    {
-        $builder = new SchemaBuilder();
-        $resource = app(OpenApiStubWithNoCastModelResource::class);
-
-        $attributes = $builder->buildAttributesSchema($resource);
-
-        $this->assertSame('object', $attributes['type']);
-        $this->assertTrue($attributes['additionalProperties']);
-    }
-
-    #[Test]
-    #[TestDox('it maps all cast types to OpenAPI types')]
-    public function it_maps_all_cast_types(): void
-    {
-        $builder = new SchemaBuilder();
-        $resource = app(OpenApiStubWithAllCastsModelResource::class);
-
-        $attributes = $builder->buildAttributesSchema($resource);
-        $props = $attributes['properties'];
-
-        $this->assertSame('integer', $props['count']['type']);
-        $this->assertSame('number', $props['price']['type']);
-        $this->assertSame('number', $props['precise_price']['type']);
-        $this->assertSame('boolean', $props['active']['type']);
-        $this->assertSame('string', $props['name']['type']);
-        $this->assertSame('object', $props['settings']['type']);
-        $this->assertSame('string', $props['birthday']['type']);
-        $this->assertSame('date', $props['birthday']['format']);
-        $this->assertSame('string', $props['created_at']['type']);
-        $this->assertSame('date-time', $props['created_at']['format']);
-        $this->assertSame('integer', $props['unix_ts']['type']);
-        $this->assertSame('string', $props['secret']['type']);
-    }
-
-    #[Test]
-    #[TestDox('it maps backed enum cast to OpenAPI enum')]
-    public function it_maps_backed_enum(): void
-    {
-        $builder = new SchemaBuilder();
-        $resource = app(OpenApiStubWithEnumCastModelResource::class);
-
-        $attributes = $builder->buildAttributesSchema($resource);
-        $props = $attributes['properties'];
-
-        $this->assertSame('string', $props['status']['type']);
-        $this->assertContains('active', $props['status']['enum']);
-        $this->assertContains('inactive', $props['status']['enum']);
-    }
-
-    #[Test]
-    #[TestDox('it maps integer backed enum cast')]
-    public function it_maps_integer_backed_enum(): void
-    {
-        $builder = new SchemaBuilder();
-        $resource = app(OpenApiStubWithIntEnumCastModelResource::class);
-
-        $attributes = $builder->buildAttributesSchema($resource);
-        $props = $attributes['properties'];
-
-        $this->assertSame('integer', $props['priority']['type']);
-        $this->assertContains(1, $props['priority']['enum']);
-    }
-
-    #[Test]
-    #[TestDox('it resolves default filter type')]
-    public function it_resolves_default_filter_type(): void
-    {
-        $builder = new SchemaBuilder();
-        $params = $builder->buildQueryParameters(OpenApiStubWithCustomFilterResource::class);
-
-        $param = collect($params)->firstWhere('name', 'filter[custom]');
-        $this->assertSame('string', $param['schema']['type']);
-    }
-
-    #[Test]
-    #[TestDox('it skips id, password, remember_token from model casts')]
-    public function it_skips_internal_columns(): void
-    {
-        $builder = new SchemaBuilder();
-        $resource = app(OpenApiStubWithInternalCastsModelResource::class);
-
-        $attributes = $builder->buildAttributesSchema($resource);
-        $props = $attributes['properties'] ?? [];
-
-        $this->assertArrayNotHasKey('id', $props);
-        $this->assertArrayNotHasKey('password', $props);
-        $this->assertArrayNotHasKey('remember_token', $props);
-        $this->assertArrayHasKey('name', $props);
-    }
-}
+
+it('builds a resource schema with type and id', function () {
+    $builder = new SchemaBuilder();
+    $schema = $builder->buildResourceSchema(OpenApiStubResource::class);
+
+    expect($schema['type'])->toBe('object');
+    expect($schema['required'])->toContain('type');
+    expect($schema['required'])->toContain('id');
+    expect($schema['required'])->toContain('attributes');
+    expect($schema['properties']['type']['type'])->toBe('string');
+    expect($schema['properties']['type']['example'])->toBe('stubs');
+});
+
+it('builds attributes from schema method', function () {
+    $builder = new SchemaBuilder();
+    $schema = $builder->buildResourceSchema(OpenApiStubWithSchemaResource::class);
+
+    $attributes = $schema['properties']['attributes'];
+
+    expect($attributes['properties']['name']['type'])->toBe('string');
+    expect($attributes['properties']['quantity']['type'])->toBe('integer');
+    expect($attributes['properties']['active']['type'])->toBe('boolean');
+});
+
+it('builds relationships schema', function () {
+    $builder = new SchemaBuilder();
+    $schema = $builder->buildResourceSchema(OpenApiStubWithRelationshipsResource::class);
+
+    $relationships = $schema['properties']['relationships'];
+
+    expect($relationships['properties'])->toHaveKey('category');
+    expect($relationships['properties']['category']['properties']['data']['oneOf'][0]['properties']['type']['example'])->toBe('categories');
+});
+
+it('builds query parameters from resource', function () {
+    $builder = new SchemaBuilder();
+    $params = $builder->buildQueryParameters(OpenApiStubWithFiltersResource::class);
+
+    $paramNames = array_column($params, 'name');
+
+    expect($paramNames)->toContain('filter[name]');
+    expect($paramNames)->toContain('filter[status]');
+    expect($paramNames)->toContain('sort');
+    expect($paramNames)->toContain('include');
+    expect($paramNames)->toContain('page[number]');
+    expect($paramNames)->toContain('page[size]');
+    expect($paramNames)->toContain('page[cursor]');
+});
+
+it('builds collection schema', function () {
+    $builder = new SchemaBuilder();
+    $schema = $builder->buildCollectionSchema(OpenApiStubResource::class);
+
+    expect($schema['properties']['data']['type'])->toBe('array');
+    expect($schema['properties']['data']['items']['$ref'])->toBe('#/components/schemas/OpenApiStub');
+    expect($schema['properties'])->toHaveKey('meta');
+    expect($schema['properties'])->toHaveKey('links');
+});
+
+it('builds single resource response schema', function () {
+    $builder = new SchemaBuilder();
+    $schema = $builder->buildSingleSchema(OpenApiStubResource::class);
+
+    expect($schema['properties']['data']['$ref'])->toBe('#/components/schemas/OpenApiStub');
+});
+
+it('builds error schema', function () {
+    $builder = new SchemaBuilder();
+    $schema = $builder->buildErrorSchema();
+
+    expect($schema['properties']['errors']['type'])->toBe('array');
+    expect($schema['properties']['errors']['items']['properties'])->toHaveKey('status');
+    expect($schema['properties']['errors']['items']['properties'])->toHaveKey('title');
+    expect($schema['properties']['errors']['items']['properties'])->toHaveKey('detail');
+});
+
+it('generates schema name from resource class', function () {
+    $builder = new SchemaBuilder();
+
+    expect($builder->schemaName(OpenApiStubResource::class))->toBe('OpenApiStub');
+    expect($builder->schemaName(OpenApiStubWithSchemaResource::class))->toBe('OpenApiStubWithSchema');
+});
+
+it('falls back to additionalProperties when no schema and no model', function () {
+    $builder = new SchemaBuilder();
+    $resource = app(OpenApiStubResource::class);
+
+    $attributes = $builder->buildAttributesSchema($resource);
+
+    expect($attributes['type'])->toBe('object');
+    expect($attributes['additionalProperties'])->toBeTrue();
+});
+
+it('infers attributes schema from model casts', function () {
+    $builder = new SchemaBuilder();
+    $resource = app(OpenApiStubWithModelResource::class);
+
+    $attributes = $builder->buildAttributesSchema($resource);
+
+    expect($attributes['type'])->toBe('object');
+    expect($attributes['properties']['price_in_cents']['type'])->toBe('integer');
+    expect($attributes['properties']['featured']['type'])->toBe('boolean');
+});
+
+it('returns empty relationships schema when none defined', function () {
+    $builder = new SchemaBuilder();
+    $resource = app(OpenApiStubResource::class);
+
+    $relationships = $builder->buildRelationshipsSchema($resource);
+
+    expect($relationships['type'])->toBe('object');
+    expect($relationships)->not->toHaveKey('properties');
+});
+
+it('builds query parameters without sorts or includes', function () {
+    $builder = new SchemaBuilder();
+    $params = $builder->buildQueryParameters(OpenApiStubResource::class);
+
+    $paramNames = array_column($params, 'name');
+
+    expect($paramNames)->toContain('page[number]');
+    expect($paramNames)->toContain('page[size]');
+    expect($paramNames)->toContain('page[cursor]');
+
+    expect($paramNames)->not->toContain('sort');
+    expect($paramNames)->not->toContain('include');
+});
+
+it('resolves DateFilter type', function () {
+    $builder = new SchemaBuilder();
+    $params = $builder->buildQueryParameters(OpenApiStubWithDateFilterResource::class);
+
+    $dateParam = collect($params)->firstWhere('name', 'filter[created_at]');
+
+    expect($dateParam['schema']['format'])->toBe('date');
+    expect($dateParam['schema']['type'])->toBe('string');
+});
+
+it('resolves filter type from class string', function () {
+    $builder = new SchemaBuilder();
+    $params = $builder->buildQueryParameters(OpenApiStubWithClassStringFilterResource::class);
+
+    $paramNames = array_column($params, 'name');
+    expect($paramNames)->toContain('filter[status]');
+});
+
+it('normalizes schema with array definitions', function () {
+    $builder = new SchemaBuilder();
+    $schema = $builder->buildResourceSchema(OpenApiStubWithMixedSchemaResource::class);
+
+    $attributes = $schema['properties']['attributes'];
+
+    expect($attributes['properties']['name']['type'])->toBe('string');
+    expect($attributes['properties']['description']['type'])->toBe('string');
+    expect($attributes['properties']['description']['nullable'])->toBeTrue();
+});
+
+it('maps all type shorthands to OpenAPI types', function () {
+    $builder = new SchemaBuilder();
+    $schema = $builder->buildResourceSchema(OpenApiStubWithAllTypesResource::class);
+
+    $props = $schema['properties']['attributes']['properties'];
+
+    expect($props['name']['type'])->toBe('string');
+    expect($props['count']['type'])->toBe('integer');
+    expect($props['price']['type'])->toBe('number');
+    expect($props['active']['type'])->toBe('boolean');
+    expect($props['tags']['type'])->toBe('array');
+    expect($props['metadata']['type'])->toBe('object');
+    expect($props['birthday']['format'])->toBe('date');
+    expect($props['created_at']['format'])->toBe('date-time');
+});
+
+it('handles sort parameter without default sort', function () {
+    $builder = new SchemaBuilder();
+    $params = $builder->buildQueryParameters(OpenApiStubWithSortsOnlyResource::class);
+
+    $sortParam = collect($params)->firstWhere('name', 'sort');
+
+    expect($sortParam['schema']['example'])->toBe('name');
+    expect($sortParam['description'])->toContain('name, created_at');
+});
+
+it('infers enum cast from model', function () {
+    $builder = new SchemaBuilder();
+    $resource = app(OpenApiStubWithEnumModelResource::class);
+
+    $attributes = $builder->buildAttributesSchema($resource);
+
+    expect($attributes['type'])->toBe('object');
+});
+
+it('falls back when model has no casts', function () {
+    $builder = new SchemaBuilder();
+    $resource = app(OpenApiStubWithNoCastModelResource::class);
+
+    $attributes = $builder->buildAttributesSchema($resource);
+
+    expect($attributes['type'])->toBe('object');
+    expect($attributes['additionalProperties'])->toBeTrue();
+});
+
+it('maps all cast types to OpenAPI types', function () {
+    $builder = new SchemaBuilder();
+    $resource = app(OpenApiStubWithAllCastsModelResource::class);
+
+    $attributes = $builder->buildAttributesSchema($resource);
+    $props = $attributes['properties'];
+
+    expect($props['count']['type'])->toBe('integer');
+    expect($props['price']['type'])->toBe('number');
+    expect($props['precise_price']['type'])->toBe('number');
+    expect($props['active']['type'])->toBe('boolean');
+    expect($props['name']['type'])->toBe('string');
+    expect($props['settings']['type'])->toBe('object');
+    expect($props['birthday']['type'])->toBe('string');
+    expect($props['birthday']['format'])->toBe('date');
+    expect($props['created_at']['type'])->toBe('string');
+    expect($props['created_at']['format'])->toBe('date-time');
+    expect($props['unix_ts']['type'])->toBe('integer');
+    expect($props['secret']['type'])->toBe('string');
+});
+
+it('maps backed enum cast to OpenAPI enum', function () {
+    $builder = new SchemaBuilder();
+    $resource = app(OpenApiStubWithEnumCastModelResource::class);
+
+    $attributes = $builder->buildAttributesSchema($resource);
+    $props = $attributes['properties'];
+
+    expect($props['status']['type'])->toBe('string');
+    expect($props['status']['enum'])->toContain('active');
+    expect($props['status']['enum'])->toContain('inactive');
+});
+
+it('maps integer backed enum cast', function () {
+    $builder = new SchemaBuilder();
+    $resource = app(OpenApiStubWithIntEnumCastModelResource::class);
+
+    $attributes = $builder->buildAttributesSchema($resource);
+    $props = $attributes['properties'];
+
+    expect($props['priority']['type'])->toBe('integer');
+    expect($props['priority']['enum'])->toContain(1);
+});
+
+it('resolves default filter type', function () {
+    $builder = new SchemaBuilder();
+    $params = $builder->buildQueryParameters(OpenApiStubWithCustomFilterResource::class);
+
+    $param = collect($params)->firstWhere('name', 'filter[custom]');
+    expect($param['schema']['type'])->toBe('string');
+});
+
+it('skips id, password, remember_token from model casts', function () {
+    $builder = new SchemaBuilder();
+    $resource = app(OpenApiStubWithInternalCastsModelResource::class);
+
+    $attributes = $builder->buildAttributesSchema($resource);
+    $props = $attributes['properties'] ?? [];
+
+    expect($props)->not->toHaveKey('id');
+    expect($props)->not->toHaveKey('password');
+    expect($props)->not->toHaveKey('remember_token');
+    expect($props)->toHaveKey('name');
+});

--- a/tests/Feature/Pagination/CursorPaginatorTest.php
+++ b/tests/Feature/Pagination/CursorPaginatorTest.php
@@ -7,92 +7,74 @@ namespace BlueBeetle\ApiToolkit\Tests\Feature\Pagination;
 use BlueBeetle\ApiToolkit\Pagination\CursorPaginator;
 use BlueBeetle\ApiToolkit\Parsers\PageParser;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\Product;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
 use Illuminate\Contracts\Pagination\CursorPaginator as CursorPaginatorContract;
 use Illuminate\Http\Request;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
 
-final class CursorPaginatorTest extends TestCase
+function createProducts(int $count): void
 {
-    #[Test]
-    #[TestDox('it cursor paginates with default page size')]
-    public function it_cursor_paginates_with_defaults(): void
-    {
-        $this->createProducts(5);
-
-        $request = Request::create('/');
-        $paginator = new CursorPaginator(new PageParser(defaultSize: 20, maxSize: 100));
-
-        $result = $paginator->paginate($request, Product::query());
-
-        $this->assertInstanceOf(CursorPaginatorContract::class, $result);
-        $this->assertSame(20, $result->perPage());
-        $this->assertCount(5, $result->items());
-    }
-
-    #[Test]
-    #[TestDox('it respects custom page size from request')]
-    public function it_respects_page_size(): void
-    {
-        $this->createProducts(5);
-
-        $request = Request::create('/', 'GET', ['page' => ['size' => 2]]);
-        $paginator = new CursorPaginator(new PageParser(defaultSize: 20, maxSize: 100));
-
-        $result = $paginator->paginate($request, Product::query());
-
-        $this->assertSame(2, $result->perPage());
-        $this->assertCount(2, $result->items());
-        $this->assertTrue($result->hasMorePages());
-    }
-
-    #[Test]
-    #[TestDox('it paginates with a cursor value')]
-    public function it_paginates_with_cursor(): void
-    {
-        $this->createProducts(5);
-
-        $initialRequest = Request::create('/', 'GET', ['page' => ['size' => 2]]);
-        $initialPaginator = new CursorPaginator(new PageParser(defaultSize: 20, maxSize: 100));
-        $initialResult = $initialPaginator->paginate($initialRequest, Product::query());
-
-        $nextCursor = $initialResult->nextCursor()?->encode();
-        $this->assertNotNull($nextCursor);
-
-        $request = Request::create('/', 'GET', ['page' => ['size' => 2, 'cursor' => $nextCursor]]);
-        $paginator = new CursorPaginator(new PageParser(defaultSize: 20, maxSize: 100));
-
-        $result = $paginator->paginate($request, Product::query());
-
-        $this->assertCount(2, $result->items());
-    }
-
-    #[Test]
-    #[TestDox('it handles null cursor gracefully')]
-    public function it_handles_null_cursor(): void
-    {
-        $this->createProducts(3);
-
-        $request = Request::create('/', 'GET', ['page' => ['size' => 10]]);
-        $paginator = new CursorPaginator(new PageParser(defaultSize: 20, maxSize: 100));
-
-        $result = $paginator->paginate($request, Product::query());
-
-        $this->assertCount(3, $result->items());
-        $this->assertFalse($result->hasMorePages());
-    }
-
-    private function createProducts(int $count): void
-    {
-        for ($i = 1; $i <= $count; $i++) {
-            Product::create([
-                'public_id' => "prod-{$i}",
-                'name' => "Product {$i}",
-                'code' => "P{$i}",
-                'price_in_cents' => $i * 1000,
-                'featured' => false,
-            ]);
-        }
+    for ($i = 1; $i <= $count; $i++) {
+        Product::create([
+            'public_id' => "prod-{$i}",
+            'name' => "Product {$i}",
+            'code' => "P{$i}",
+            'price_in_cents' => $i * 1000,
+            'featured' => false,
+        ]);
     }
 }
+
+it('cursor paginates with default page size', function () {
+    createProducts(5);
+
+    $request = Request::create('/');
+    $paginator = new CursorPaginator(new PageParser(defaultSize: 20, maxSize: 100));
+
+    $result = $paginator->paginate($request, Product::query());
+
+    expect($result)->toBeInstanceOf(CursorPaginatorContract::class);
+    expect($result->perPage())->toBe(20);
+    expect($result->items())->toHaveCount(5);
+});
+
+it('respects custom page size from request', function () {
+    createProducts(5);
+
+    $request = Request::create('/', 'GET', ['page' => ['size' => 2]]);
+    $paginator = new CursorPaginator(new PageParser(defaultSize: 20, maxSize: 100));
+
+    $result = $paginator->paginate($request, Product::query());
+
+    expect($result->perPage())->toBe(2);
+    expect($result->items())->toHaveCount(2);
+    expect($result->hasMorePages())->toBeTrue();
+});
+
+it('paginates with a cursor value', function () {
+    createProducts(5);
+
+    $initialRequest = Request::create('/', 'GET', ['page' => ['size' => 2]]);
+    $initialPaginator = new CursorPaginator(new PageParser(defaultSize: 20, maxSize: 100));
+    $initialResult = $initialPaginator->paginate($initialRequest, Product::query());
+
+    $nextCursor = $initialResult->nextCursor()?->encode();
+    expect($nextCursor)->not->toBeNull();
+
+    $request = Request::create('/', 'GET', ['page' => ['size' => 2, 'cursor' => $nextCursor]]);
+    $paginator = new CursorPaginator(new PageParser(defaultSize: 20, maxSize: 100));
+
+    $result = $paginator->paginate($request, Product::query());
+
+    expect($result->items())->toHaveCount(2);
+});
+
+it('handles null cursor gracefully', function () {
+    createProducts(3);
+
+    $request = Request::create('/', 'GET', ['page' => ['size' => 10]]);
+    $paginator = new CursorPaginator(new PageParser(defaultSize: 20, maxSize: 100));
+
+    $result = $paginator->paginate($request, Product::query());
+
+    expect($result->items())->toHaveCount(3);
+    expect($result->hasMorePages())->toBeFalse();
+});

--- a/tests/Feature/Pagination/OffsetPaginatorTest.php
+++ b/tests/Feature/Pagination/OffsetPaginatorTest.php
@@ -7,85 +7,67 @@ namespace BlueBeetle\ApiToolkit\Tests\Feature\Pagination;
 use BlueBeetle\ApiToolkit\Pagination\OffsetPaginator;
 use BlueBeetle\ApiToolkit\Parsers\PageParser;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\Product;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Http\Request;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
 
-final class OffsetPaginatorTest extends TestCase
+function createOffsetProducts(int $count): void
 {
-    #[Test]
-    #[TestDox('it paginates with default page size and page number')]
-    public function it_paginates_with_defaults(): void
-    {
-        $this->createProducts(5);
-
-        $request = Request::create('/');
-        $paginator = new OffsetPaginator(new PageParser(defaultSize: 20, maxSize: 100));
-
-        $result = $paginator->paginate($request, Product::query());
-
-        $this->assertInstanceOf(LengthAwarePaginator::class, $result);
-        $this->assertSame(20, $result->perPage());
-        $this->assertSame(1, $result->currentPage());
-        $this->assertSame(5, $result->total());
-    }
-
-    #[Test]
-    #[TestDox('it respects custom page size from request')]
-    public function it_respects_custom_page_size(): void
-    {
-        $this->createProducts(5);
-
-        $request = Request::create('/', 'GET', ['page' => ['size' => 2]]);
-        $paginator = new OffsetPaginator(new PageParser(defaultSize: 20, maxSize: 100));
-
-        $result = $paginator->paginate($request, Product::query());
-
-        $this->assertSame(2, $result->perPage());
-        $this->assertCount(2, $result->items());
-    }
-
-    #[Test]
-    #[TestDox('it respects page number from request')]
-    public function it_respects_page_number(): void
-    {
-        $this->createProducts(5);
-
-        $request = Request::create('/', 'GET', ['page' => ['size' => 2, 'number' => 2]]);
-        $paginator = new OffsetPaginator(new PageParser(defaultSize: 20, maxSize: 100));
-
-        $result = $paginator->paginate($request, Product::query());
-
-        $this->assertSame(2, $result->currentPage());
-        $this->assertCount(2, $result->items());
-    }
-
-    #[Test]
-    #[TestDox('it uses custom PageParser configuration')]
-    public function it_uses_custom_page_parser(): void
-    {
-        $this->createProducts(5);
-
-        $request = Request::create('/');
-        $paginator = new OffsetPaginator(new PageParser(defaultSize: 3, maxSize: 10));
-
-        $result = $paginator->paginate($request, Product::query());
-
-        $this->assertSame(3, $result->perPage());
-    }
-
-    private function createProducts(int $count): void
-    {
-        for ($i = 1; $i <= $count; $i++) {
-            Product::create([
-                'public_id' => "prod-{$i}",
-                'name' => "Product {$i}",
-                'code' => "P{$i}",
-                'price_in_cents' => $i * 1000,
-                'featured' => false,
-            ]);
-        }
+    for ($i = 1; $i <= $count; $i++) {
+        Product::create([
+            'public_id' => "prod-{$i}",
+            'name' => "Product {$i}",
+            'code' => "P{$i}",
+            'price_in_cents' => $i * 1000,
+            'featured' => false,
+        ]);
     }
 }
+
+it('paginates with default page size and page number', function () {
+    createOffsetProducts(5);
+
+    $request = Request::create('/');
+    $paginator = new OffsetPaginator(new PageParser(defaultSize: 20, maxSize: 100));
+
+    $result = $paginator->paginate($request, Product::query());
+
+    expect($result)->toBeInstanceOf(LengthAwarePaginator::class);
+    expect($result->perPage())->toBe(20);
+    expect($result->currentPage())->toBe(1);
+    expect($result->total())->toBe(5);
+});
+
+it('respects custom page size from request', function () {
+    createOffsetProducts(5);
+
+    $request = Request::create('/', 'GET', ['page' => ['size' => 2]]);
+    $paginator = new OffsetPaginator(new PageParser(defaultSize: 20, maxSize: 100));
+
+    $result = $paginator->paginate($request, Product::query());
+
+    expect($result->perPage())->toBe(2);
+    expect($result->items())->toHaveCount(2);
+});
+
+it('respects page number from request', function () {
+    createOffsetProducts(5);
+
+    $request = Request::create('/', 'GET', ['page' => ['size' => 2, 'number' => 2]]);
+    $paginator = new OffsetPaginator(new PageParser(defaultSize: 20, maxSize: 100));
+
+    $result = $paginator->paginate($request, Product::query());
+
+    expect($result->currentPage())->toBe(2);
+    expect($result->items())->toHaveCount(2);
+});
+
+it('uses custom PageParser configuration', function () {
+    createOffsetProducts(5);
+
+    $request = Request::create('/');
+    $paginator = new OffsetPaginator(new PageParser(defaultSize: 3, maxSize: 10));
+
+    $result = $paginator->paginate($request, Product::query());
+
+    expect($result->perPage())->toBe(3);
+});

--- a/tests/Feature/Parsers/DateFilterTest.php
+++ b/tests/Feature/Parsers/DateFilterTest.php
@@ -6,59 +6,44 @@ namespace BlueBeetle\ApiToolkit\Tests\Feature\Parsers;
 
 use BlueBeetle\ApiToolkit\Parsers\Filters\DateFilter;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\Product;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
 
-final class DateFilterTest extends TestCase
-{
-    #[Test]
-    #[TestDox('it filters by exact date')]
-    public function it_filters_exact_date(): void
-    {
-        $filter = new DateFilter();
+it('filters by exact date', function () {
+    $filter = new DateFilter();
 
-        $query = Product::query();
-        $filter->apply($query, 'created_at', '2025-01-15');
+    $query = Product::query();
+    $filter->apply($query, 'created_at', '2025-01-15');
 
-        $sql = $query->toSql();
-        $bindings = $query->getBindings();
+    $sql = $query->toSql();
+    $bindings = $query->getBindings();
 
-        $this->assertStringContainsString('created_at', $sql);
-        $this->assertContains('2025-01-15', $bindings);
-    }
+    expect($sql)->toContain('created_at');
+    expect($bindings)->toContain('2025-01-15');
+});
 
-    #[Test]
-    #[TestDox('it filters by date range with from')]
-    public function it_filters_date_from(): void
-    {
-        $filter = new DateFilter();
+it('filters by date range with from', function () {
+    $filter = new DateFilter();
 
-        $query = Product::query();
-        $filter->apply($query, 'created_at', ['from' => '2025-01-01']);
+    $query = Product::query();
+    $filter->apply($query, 'created_at', ['from' => '2025-01-01']);
 
-        $sql = $query->toSql();
-        $bindings = $query->getBindings();
+    $sql = $query->toSql();
+    $bindings = $query->getBindings();
 
-        $this->assertStringContainsString('created_at', $sql);
-        $this->assertStringContainsString('>=', $sql);
-        $this->assertContains('2025-01-01', $bindings);
-    }
+    expect($sql)->toContain('created_at');
+    expect($sql)->toContain('>=');
+    expect($bindings)->toContain('2025-01-01');
+});
 
-    #[Test]
-    #[TestDox('it filters by date range with from and to')]
-    public function it_filters_date_range(): void
-    {
-        $filter = new DateFilter();
+it('filters by date range with from and to', function () {
+    $filter = new DateFilter();
 
-        $query = Product::query();
-        $filter->apply($query, 'created_at', ['from' => '2025-01-01', 'to' => '2025-12-31']);
+    $query = Product::query();
+    $filter->apply($query, 'created_at', ['from' => '2025-01-01', 'to' => '2025-12-31']);
 
-        $sql = $query->toSql();
-        $bindings = $query->getBindings();
+    $sql = $query->toSql();
+    $bindings = $query->getBindings();
 
-        $this->assertStringContainsString('created_at', $sql);
-        $this->assertContains('2025-01-01', $bindings);
-        $this->assertContains('2025-12-31', $bindings);
-    }
-}
+    expect($sql)->toContain('created_at');
+    expect($bindings)->toContain('2025-01-01');
+    expect($bindings)->toContain('2025-12-31');
+});

--- a/tests/Feature/Parsers/FieldParserTest.php
+++ b/tests/Feature/Parsers/FieldParserTest.php
@@ -5,124 +5,94 @@ declare(strict_types = 1);
 namespace BlueBeetle\ApiToolkit\Tests\Feature\Parsers;
 
 use BlueBeetle\ApiToolkit\Parsers\FieldParser;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
 use Illuminate\Http\Request;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
 
-final class FieldParserTest extends TestCase
-{
-    #[Test]
-    #[TestDox('it parses sparse fieldsets')]
-    public function it_parses_fields(): void
-    {
-        $parser = new FieldParser();
+it('parses sparse fieldsets', function () {
+    $parser = new FieldParser();
 
-        $request = Request::create('/', 'GET', ['fields' => ['products' => 'name,code']]);
+    $request = Request::create('/', 'GET', ['fields' => ['products' => 'name,code']]);
 
-        $result = $parser->parse($request);
+    $result = $parser->parse($request);
 
-        $this->assertSame(['name', 'code'], $result['products']);
-    }
+    expect($result['products'])->toBe(['name', 'code']);
+});
 
-    #[Test]
-    #[TestDox('it parses multiple resource type fieldsets')]
-    public function it_parses_multiple_types(): void
-    {
-        $parser = new FieldParser();
+it('parses multiple resource type fieldsets', function () {
+    $parser = new FieldParser();
 
-        $request = Request::create('/', 'GET', [
-            'fields' => [
-                'products' => 'name,code',
-                'categories' => 'name',
-            ],
-        ]);
+    $request = Request::create('/', 'GET', [
+        'fields' => [
+            'products' => 'name,code',
+            'categories' => 'name',
+        ],
+    ]);
 
-        $result = $parser->parse($request);
+    $result = $parser->parse($request);
 
-        $this->assertSame(['name', 'code'], $result['products']);
-        $this->assertSame(['name'], $result['categories']);
-    }
+    expect($result['products'])->toBe(['name', 'code']);
+    expect($result['categories'])->toBe(['name']);
+});
 
-    #[Test]
-    #[TestDox('it returns empty array when no fields param')]
-    public function it_returns_empty_without_param(): void
-    {
-        $parser = new FieldParser();
+it('returns empty array when no fields param', function () {
+    $parser = new FieldParser();
 
-        $request = Request::create('/');
+    $request = Request::create('/');
 
-        $this->assertSame([], $parser->parse($request));
-    }
+    expect($parser->parse($request))->toBe([]);
+});
 
-    #[Test]
-    #[TestDox('it filters attributes to requested fields')]
-    public function it_filters_attributes(): void
-    {
-        $parser = new FieldParser();
+it('filters attributes to requested fields', function () {
+    $parser = new FieldParser();
 
-        $attributes = ['name' => 'Widget', 'code' => 'W01', 'description' => 'A widget'];
+    $attributes = ['name' => 'Widget', 'code' => 'W01', 'description' => 'A widget'];
 
-        $result = $parser->filter($attributes, ['name', 'code']);
+    $result = $parser->filter($attributes, ['name', 'code']);
 
-        $this->assertSame(['name' => 'Widget', 'code' => 'W01'], $result);
-    }
+    expect($result)->toBe(['name' => 'Widget', 'code' => 'W01']);
+});
 
-    #[Test]
-    #[TestDox('it returns all attributes when fields is null')]
-    public function it_returns_all_when_null(): void
-    {
-        $parser = new FieldParser();
+it('returns all attributes when fields is null', function () {
+    $parser = new FieldParser();
 
-        $attributes = ['name' => 'Widget', 'code' => 'W01'];
+    $attributes = ['name' => 'Widget', 'code' => 'W01'];
 
-        $result = $parser->filter($attributes, null);
+    $result = $parser->filter($attributes, null);
 
-        $this->assertSame($attributes, $result);
-    }
+    expect($result)->toBe($attributes);
+});
 
-    #[Test]
-    #[TestDox('it returns all attributes when fields is empty')]
-    public function it_returns_all_when_empty(): void
-    {
-        $parser = new FieldParser();
+it('returns all attributes when fields is empty', function () {
+    $parser = new FieldParser();
 
-        $attributes = ['name' => 'Widget', 'code' => 'W01'];
+    $attributes = ['name' => 'Widget', 'code' => 'W01'];
 
-        $result = $parser->filter($attributes, []);
+    $result = $parser->filter($attributes, []);
 
-        $this->assertSame($attributes, $result);
-    }
+    expect($result)->toBe($attributes);
+});
 
-    #[Test]
-    #[TestDox('it returns empty when fields param is not an array')]
-    public function it_returns_empty_for_non_array_fields(): void
-    {
-        $parser = new FieldParser();
+it('returns empty when fields param is not an array', function () {
+    $parser = new FieldParser();
 
-        $request = Request::create('/', 'GET', ['fields' => 'not-an-array']);
+    $request = Request::create('/', 'GET', ['fields' => 'not-an-array']);
 
-        $this->assertSame([], $parser->parse($request));
-    }
+    expect($parser->parse($request))->toBe([]);
+});
 
-    #[Test]
-    #[TestDox('it skips non-string or empty field values')]
-    public function it_skips_invalid_field_values(): void
-    {
-        $parser = new FieldParser();
+it('skips non-string or empty field values', function () {
+    $parser = new FieldParser();
 
-        $request = Request::create('/', 'GET', [
-            'fields' => [
-                'products' => 'name,code',
-                'categories' => '',
-                'tags' => ['not', 'a', 'string'],
-            ],
-        ]);
+    $request = Request::create('/', 'GET', [
+        'fields' => [
+            'products' => 'name,code',
+            'categories' => '',
+            'tags' => ['not', 'a', 'string'],
+        ],
+    ]);
 
-        $result = $parser->parse($request);
+    $result = $parser->parse($request);
 
-        $this->assertSame(['name', 'code'], $result['products']);
-        $this->assertArrayNotHasKey('categories', $result);
-        $this->assertArrayNotHasKey('tags', $result);
-    }
-}
+    expect($result['products'])->toBe(['name', 'code']);
+    expect($result)->not->toHaveKey('categories');
+    expect($result)->not->toHaveKey('tags');
+});

--- a/tests/Feature/Parsers/FilterParserTest.php
+++ b/tests/Feature/Parsers/FilterParserTest.php
@@ -8,160 +8,129 @@ use BlueBeetle\ApiToolkit\Parsers\FilterParser;
 use BlueBeetle\ApiToolkit\Parsers\Filters\ExactFilter;
 use BlueBeetle\ApiToolkit\Parsers\Filters\PartialFilter;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\Product;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
 use Illuminate\Http\Request;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
 
-final class FilterParserTest extends TestCase
-{
-    #[Test]
-    #[TestDox('it applies exact filter')]
-    public function it_applies_exact_filter(): void
-    {
-        $parser = new FilterParser([
-            'status' => new ExactFilter(),
-        ]);
+it('applies exact filter', function () {
+    $parser = new FilterParser([
+        'status' => new ExactFilter(),
+    ]);
 
-        $request = Request::create('/', 'GET', ['filter' => ['status' => 'active']]);
-        $query = Product::query();
+    $request = Request::create('/', 'GET', ['filter' => ['status' => 'active']]);
+    $query = Product::query();
 
-        $parser->apply($request, $query);
+    $parser->apply($request, $query);
 
-        $sql = $query->toSql();
-        $bindings = $query->getBindings();
+    $sql = $query->toSql();
+    $bindings = $query->getBindings();
 
-        $this->assertStringContainsString('status', $sql);
-        $this->assertStringContainsString('=', $sql);
-        $this->assertContains('active', $bindings);
-    }
+    expect($sql)->toContain('status');
+    expect($sql)->toContain('=');
+    expect($bindings)->toContain('active');
+});
 
-    #[Test]
-    #[TestDox('it applies exact filter with array value as whereIn')]
-    public function it_applies_exact_filter_with_array(): void
-    {
-        $parser = new FilterParser([
-            'status' => new ExactFilter(),
-        ]);
+it('applies exact filter with array value as whereIn', function () {
+    $parser = new FilterParser([
+        'status' => new ExactFilter(),
+    ]);
 
-        $request = Request::create('/', 'GET', ['filter' => ['status' => ['active', 'pending']]]);
-        $query = Product::query();
+    $request = Request::create('/', 'GET', ['filter' => ['status' => ['active', 'pending']]]);
+    $query = Product::query();
 
-        $parser->apply($request, $query);
+    $parser->apply($request, $query);
 
-        $sql = $query->toSql();
-        $bindings = $query->getBindings();
+    $sql = $query->toSql();
+    $bindings = $query->getBindings();
 
-        $this->assertStringContainsString('status', $sql);
-        $this->assertStringContainsString('in', mb_strtolower($sql));
-        $this->assertContains('active', $bindings);
-        $this->assertContains('pending', $bindings);
-    }
+    expect($sql)->toContain('status');
+    expect(mb_strtolower($sql))->toContain('in');
+    expect($bindings)->toContain('active');
+    expect($bindings)->toContain('pending');
+});
 
-    #[Test]
-    #[TestDox('it applies partial filter')]
-    public function it_applies_partial_filter(): void
-    {
-        $parser = new FilterParser([
-            'name' => new PartialFilter(),
-        ]);
+it('applies partial filter', function () {
+    $parser = new FilterParser([
+        'name' => new PartialFilter(),
+    ]);
 
-        $request = Request::create('/', 'GET', ['filter' => ['name' => 'wid']]);
-        $query = Product::query();
+    $request = Request::create('/', 'GET', ['filter' => ['name' => 'wid']]);
+    $query = Product::query();
 
-        $parser->apply($request, $query);
+    $parser->apply($request, $query);
 
-        $sql = $query->toSql();
-        $bindings = $query->getBindings();
+    $sql = $query->toSql();
+    $bindings = $query->getBindings();
 
-        $this->assertStringContainsString('name', $sql);
-        $this->assertStringContainsString('like', mb_strtolower($sql));
-        $this->assertContains('%wid%', $bindings);
-    }
+    expect($sql)->toContain('name');
+    expect(mb_strtolower($sql))->toContain('like');
+    expect($bindings)->toContain('%wid%');
+});
 
-    #[Test]
-    #[TestDox('it ignores unknown filter fields')]
-    public function it_ignores_unknown_fields(): void
-    {
-        $parser = new FilterParser([
-            'status' => new ExactFilter(),
-        ]);
+it('ignores unknown filter fields', function () {
+    $parser = new FilterParser([
+        'status' => new ExactFilter(),
+    ]);
 
-        $request = Request::create('/', 'GET', ['filter' => ['unknown' => 'value']]);
-        $query = Product::query();
+    $request = Request::create('/', 'GET', ['filter' => ['unknown' => 'value']]);
+    $query = Product::query();
 
-        $parser->apply($request, $query);
+    $parser->apply($request, $query);
 
-        $sql = $query->toSql();
+    $sql = $query->toSql();
 
-        $this->assertStringNotContainsString('unknown', $sql);
-    }
+    expect($sql)->not->toContain('unknown');
+});
 
-    #[Test]
-    #[TestDox('it handles missing filter parameter')]
-    public function it_handles_missing_filter(): void
-    {
-        $parser = new FilterParser([
-            'status' => new ExactFilter(),
-        ]);
+it('handles missing filter parameter', function () {
+    $parser = new FilterParser([
+        'status' => new ExactFilter(),
+    ]);
 
-        $request = Request::create('/');
-        $query = Product::query();
+    $request = Request::create('/');
+    $query = Product::query();
 
-        $parser->apply($request, $query);
+    $parser->apply($request, $query);
 
-        $sql = $query->toSql();
-        $bindings = $query->getBindings();
+    $sql = $query->toSql();
+    $bindings = $query->getBindings();
 
-        // Only the soft-delete where clause should be present, no filter bindings
-        $this->assertEmpty($bindings);
-    }
+    expect($bindings)->toBeEmpty();
+});
 
-    #[Test]
-    #[TestDox('it returns allowed fields')]
-    public function it_returns_allowed_fields(): void
-    {
-        $parser = new FilterParser([
-            'status' => new ExactFilter(),
-            'name' => new PartialFilter(),
-        ]);
+it('returns allowed fields', function () {
+    $parser = new FilterParser([
+        'status' => new ExactFilter(),
+        'name' => new PartialFilter(),
+    ]);
 
-        $this->assertSame(['status', 'name'], $parser->allowedFields());
-    }
+    expect($parser->allowedFields())->toBe(['status', 'name']);
+});
 
-    #[Test]
-    #[TestDox('it resolves filter from class string')]
-    public function it_resolves_filter_from_class_string(): void
-    {
-        $parser = new FilterParser([
-            'status' => ExactFilter::class,
-        ]);
+it('resolves filter from class string', function () {
+    $parser = new FilterParser([
+        'status' => ExactFilter::class,
+    ]);
 
-        $request = Request::create('/', 'GET', ['filter' => ['status' => 'active']]);
-        $query = Product::query();
+    $request = Request::create('/', 'GET', ['filter' => ['status' => 'active']]);
+    $query = Product::query();
 
-        $parser->apply($request, $query);
+    $parser->apply($request, $query);
 
-        $sql = $query->toSql();
-        $bindings = $query->getBindings();
+    $sql = $query->toSql();
+    $bindings = $query->getBindings();
 
-        $this->assertStringContainsString('status', $sql);
-        $this->assertContains('active', $bindings);
-    }
+    expect($sql)->toContain('status');
+    expect($bindings)->toContain('active');
+});
 
-    #[Test]
-    #[TestDox('it handles non-array filter parameter')]
-    public function it_handles_non_array_filter(): void
-    {
-        $parser = new FilterParser([
-            'status' => new ExactFilter(),
-        ]);
+it('handles non-array filter parameter', function () {
+    $parser = new FilterParser([
+        'status' => new ExactFilter(),
+    ]);
 
-        $request = Request::create('/', 'GET', ['filter' => 'not-an-array']);
-        $query = Product::query();
+    $request = Request::create('/', 'GET', ['filter' => 'not-an-array']);
+    $query = Product::query();
 
-        $result = $parser->apply($request, $query);
+    $parser->apply($request, $query);
 
-        $this->assertEmpty($query->getBindings());
-    }
-}
+    expect($query->getBindings())->toBeEmpty();
+});

--- a/tests/Feature/Parsers/IncludeParserTest.php
+++ b/tests/Feature/Parsers/IncludeParserTest.php
@@ -5,65 +5,44 @@ declare(strict_types = 1);
 namespace BlueBeetle\ApiToolkit\Tests\Feature\Parsers;
 
 use BlueBeetle\ApiToolkit\Parsers\IncludeParser;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
 use Illuminate\Http\Request;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
 
-final class IncludeParserTest extends TestCase
-{
-    #[Test]
-    #[TestDox('it parses comma-separated includes')]
-    public function it_parses_includes(): void
-    {
-        $parser = new IncludeParser(allowed: ['category', 'supplier']);
+it('parses comma-separated includes', function () {
+    $parser = new IncludeParser(allowed: ['category', 'supplier']);
 
-        $request = Request::create('/', 'GET', ['include' => 'category,supplier']);
+    $request = Request::create('/', 'GET', ['include' => 'category,supplier']);
 
-        $this->assertSame(['category', 'supplier'], $parser->parse($request));
-    }
+    expect($parser->parse($request))->toBe(['category', 'supplier']);
+});
 
-    #[Test]
-    #[TestDox('it filters out disallowed includes')]
-    public function it_filters_disallowed_includes(): void
-    {
-        $parser = new IncludeParser(allowed: ['category']);
+it('filters out disallowed includes', function () {
+    $parser = new IncludeParser(allowed: ['category']);
 
-        $request = Request::create('/', 'GET', ['include' => 'category,secret']);
+    $request = Request::create('/', 'GET', ['include' => 'category,secret']);
 
-        $this->assertSame(['category'], $parser->parse($request));
-    }
+    expect($parser->parse($request))->toBe(['category']);
+});
 
-    #[Test]
-    #[TestDox('it returns empty array when no include param')]
-    public function it_returns_empty_without_param(): void
-    {
-        $parser = new IncludeParser(allowed: ['category']);
+it('returns empty array when no include param', function () {
+    $parser = new IncludeParser(allowed: ['category']);
 
-        $request = Request::create('/');
+    $request = Request::create('/');
 
-        $this->assertSame([], $parser->parse($request));
-    }
+    expect($parser->parse($request))->toBe([]);
+});
 
-    #[Test]
-    #[TestDox('it allows all includes when no allowed list')]
-    public function it_allows_all_when_unrestricted(): void
-    {
-        $parser = new IncludeParser();
+it('allows all includes when no allowed list', function () {
+    $parser = new IncludeParser();
 
-        $request = Request::create('/', 'GET', ['include' => 'anything,goes']);
+    $request = Request::create('/', 'GET', ['include' => 'anything,goes']);
 
-        $this->assertSame(['anything', 'goes'], $parser->parse($request));
-    }
+    expect($parser->parse($request))->toBe(['anything', 'goes']);
+});
 
-    #[Test]
-    #[TestDox('it returns empty for empty include string')]
-    public function it_returns_empty_for_empty_string(): void
-    {
-        $parser = new IncludeParser(allowed: ['category']);
+it('returns empty for empty include string', function () {
+    $parser = new IncludeParser(allowed: ['category']);
 
-        $request = Request::create('/', 'GET', ['include' => '']);
+    $request = Request::create('/', 'GET', ['include' => '']);
 
-        $this->assertSame([], $parser->parse($request));
-    }
-}
+    expect($parser->parse($request))->toBe([]);
+});

--- a/tests/Feature/Parsers/PageParserTest.php
+++ b/tests/Feature/Parsers/PageParserTest.php
@@ -5,156 +5,111 @@ declare(strict_types = 1);
 namespace BlueBeetle\ApiToolkit\Tests\Feature\Parsers;
 
 use BlueBeetle\ApiToolkit\Parsers\PageParser;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
 use Illuminate\Http\Request;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
 
-final class PageParserTest extends TestCase
-{
-    #[Test]
-    #[TestDox('it returns default size when no page param')]
-    public function it_returns_default_size(): void
-    {
-        $parser = new PageParser(defaultSize: 20);
+it('returns default size when no page param', function () {
+    $parser = new PageParser(defaultSize: 20);
 
-        $request = Request::create('/');
+    $request = Request::create('/');
 
-        $this->assertSame(20, $parser->getSize($request));
-    }
+    expect($parser->getSize($request))->toBe(20);
+});
 
-    #[Test]
-    #[TestDox('it parses page size from request')]
-    public function it_parses_size(): void
-    {
-        $parser = new PageParser();
+it('parses page size from request', function () {
+    $parser = new PageParser();
 
-        $request = Request::create('/', 'GET', ['page' => ['size' => '40']]);
+    $request = Request::create('/', 'GET', ['page' => ['size' => '40']]);
 
-        $this->assertSame(40, $parser->getSize($request));
-    }
+    expect($parser->getSize($request))->toBe(40);
+});
 
-    #[Test]
-    #[TestDox('it clamps page size to max')]
-    public function it_clamps_to_max(): void
-    {
-        $parser = new PageParser(maxSize: 100);
+it('clamps page size to max', function () {
+    $parser = new PageParser(maxSize: 100);
 
-        $request = Request::create('/', 'GET', ['page' => ['size' => '500']]);
+    $request = Request::create('/', 'GET', ['page' => ['size' => '500']]);
 
-        $this->assertSame(100, $parser->getSize($request));
-    }
+    expect($parser->getSize($request))->toBe(100);
+});
 
-    #[Test]
-    #[TestDox('it clamps page size to minimum 1')]
-    public function it_clamps_to_min(): void
-    {
-        $parser = new PageParser();
+it('clamps page size to minimum 1', function () {
+    $parser = new PageParser();
 
-        $request = Request::create('/', 'GET', ['page' => ['size' => '0']]);
+    $request = Request::create('/', 'GET', ['page' => ['size' => '0']]);
 
-        $this->assertSame(1, $parser->getSize($request));
-    }
+    expect($parser->getSize($request))->toBe(1);
+});
 
-    #[Test]
-    #[TestDox('it returns page number')]
-    public function it_returns_page_number(): void
-    {
-        $parser = new PageParser();
+it('returns page number', function () {
+    $parser = new PageParser();
 
-        $request = Request::create('/', 'GET', ['page' => ['number' => '3']]);
+    $request = Request::create('/', 'GET', ['page' => ['number' => '3']]);
 
-        $this->assertSame(3, $parser->getNumber($request));
-    }
+    expect($parser->getNumber($request))->toBe(3);
+});
 
-    #[Test]
-    #[TestDox('it defaults to page 1')]
-    public function it_defaults_to_page_1(): void
-    {
-        $parser = new PageParser();
+it('defaults to page 1', function () {
+    $parser = new PageParser();
 
-        $request = Request::create('/');
+    $request = Request::create('/');
 
-        $this->assertSame(1, $parser->getNumber($request));
-    }
+    expect($parser->getNumber($request))->toBe(1);
+});
 
-    #[Test]
-    #[TestDox('it detects cursor pagination')]
-    public function it_detects_cursor(): void
-    {
-        $parser = new PageParser();
+it('detects cursor pagination', function () {
+    $parser = new PageParser();
 
-        $request = Request::create('/', 'GET', ['page' => ['cursor' => 'eyJpZCI6MTB9']]);
+    $request = Request::create('/', 'GET', ['page' => ['cursor' => 'eyJpZCI6MTB9']]);
 
-        $this->assertTrue($parser->isCursor($request));
-        $this->assertSame('eyJpZCI6MTB9', $parser->getCursor($request));
-    }
+    expect($parser->isCursor($request))->toBeTrue();
+    expect($parser->getCursor($request))->toBe('eyJpZCI6MTB9');
+});
 
-    #[Test]
-    #[TestDox('it detects non-cursor pagination')]
-    public function it_detects_non_cursor(): void
-    {
-        $parser = new PageParser();
+it('detects non-cursor pagination', function () {
+    $parser = new PageParser();
 
-        $request = Request::create('/', 'GET', ['page' => ['number' => '2']]);
+    $request = Request::create('/', 'GET', ['page' => ['number' => '2']]);
 
-        $this->assertFalse($parser->isCursor($request));
-        $this->assertNull($parser->getCursor($request));
-    }
+    expect($parser->isCursor($request))->toBeFalse();
+    expect($parser->getCursor($request))->toBeNull();
+});
 
-    #[Test]
-    #[TestDox('it returns null cursor when no page param')]
-    public function it_returns_null_cursor_without_param(): void
-    {
-        $parser = new PageParser();
+it('returns null cursor when no page param', function () {
+    $parser = new PageParser();
 
-        $request = Request::create('/');
+    $request = Request::create('/');
 
-        $this->assertFalse($parser->isCursor($request));
-        $this->assertNull($parser->getCursor($request));
-    }
+    expect($parser->isCursor($request))->toBeFalse();
+    expect($parser->getCursor($request))->toBeNull();
+});
 
-    #[Test]
-    #[TestDox('it handles non-array page param for isCursor')]
-    public function it_handles_non_array_page_for_is_cursor(): void
-    {
-        $parser = new PageParser();
+it('handles non-array page param for isCursor', function () {
+    $parser = new PageParser();
 
-        $request = Request::create('/', 'GET', ['page' => 'not-an-array']);
+    $request = Request::create('/', 'GET', ['page' => 'not-an-array']);
 
-        $this->assertFalse($parser->isCursor($request));
-    }
+    expect($parser->isCursor($request))->toBeFalse();
+});
 
-    #[Test]
-    #[TestDox('it handles non-array page param for getSize')]
-    public function it_handles_non_array_page_for_size(): void
-    {
-        $parser = new PageParser(defaultSize: 25);
+it('handles non-array page param for getSize', function () {
+    $parser = new PageParser(defaultSize: 25);
 
-        $request = Request::create('/', 'GET', ['page' => 'not-an-array']);
+    $request = Request::create('/', 'GET', ['page' => 'not-an-array']);
 
-        $this->assertSame(25, $parser->getSize($request));
-    }
+    expect($parser->getSize($request))->toBe(25);
+});
 
-    #[Test]
-    #[TestDox('it handles non-array page param for getNumber')]
-    public function it_handles_non_array_page_for_number(): void
-    {
-        $parser = new PageParser();
+it('handles non-array page param for getNumber', function () {
+    $parser = new PageParser();
 
-        $request = Request::create('/', 'GET', ['page' => 'not-an-array']);
+    $request = Request::create('/', 'GET', ['page' => 'not-an-array']);
 
-        $this->assertSame(1, $parser->getNumber($request));
-    }
+    expect($parser->getNumber($request))->toBe(1);
+});
 
-    #[Test]
-    #[TestDox('it handles non-array page param for getCursor')]
-    public function it_handles_non_array_page_for_cursor(): void
-    {
-        $parser = new PageParser();
+it('handles non-array page param for getCursor', function () {
+    $parser = new PageParser();
 
-        $request = Request::create('/', 'GET', ['page' => 'not-an-array']);
+    $request = Request::create('/', 'GET', ['page' => 'not-an-array']);
 
-        $this->assertNull($parser->getCursor($request));
-    }
-}
+    expect($parser->getCursor($request))->toBeNull();
+});

--- a/tests/Feature/Parsers/ScopeFilterTest.php
+++ b/tests/Feature/Parsers/ScopeFilterTest.php
@@ -5,50 +5,23 @@ declare(strict_types = 1);
 namespace BlueBeetle\ApiToolkit\Tests\Feature\Parsers;
 
 use BlueBeetle\ApiToolkit\Parsers\Filters\ScopeFilter;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
 use Illuminate\Database\Eloquent\Builder;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
+use Mockery;
 
-final class ScopeFilterTest extends TestCase
-{
-    #[Test]
-    #[TestDox('it delegates to eloquent scope using field name')]
-    public function it_delegates_to_scope(): void
-    {
-        $filter = new ScopeFilter();
+it('delegates to eloquent scope using field name', function () {
+    $filter = new ScopeFilter();
 
-        $query = $this->getMockBuilder(Builder::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['__call'])
-            ->getMock()
-        ;
+    $query = Mockery::mock(Builder::class);
+    $query->shouldReceive('active')->once()->with('yes');
 
-        $query->expects($this->once())
-            ->method('__call')
-            ->with('active', ['yes'])
-        ;
+    $filter->apply($query, 'active', 'yes');
+});
 
-        $filter->apply($query, 'active', 'yes');
-    }
+it('delegates to custom scope name', function () {
+    $filter = new ScopeFilter(scopeName: 'whereActive');
 
-    #[Test]
-    #[TestDox('it delegates to custom scope name')]
-    public function it_delegates_to_custom_scope(): void
-    {
-        $filter = new ScopeFilter(scopeName: 'whereActive');
+    $query = Mockery::mock(Builder::class);
+    $query->shouldReceive('whereActive')->once()->with('yes');
 
-        $query = $this->getMockBuilder(Builder::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['__call'])
-            ->getMock()
-        ;
-
-        $query->expects($this->once())
-            ->method('__call')
-            ->with('whereActive', ['yes'])
-        ;
-
-        $filter->apply($query, 'status', 'yes');
-    }
-}
+    $filter->apply($query, 'status', 'yes');
+});

--- a/tests/Feature/Parsers/SortParserTest.php
+++ b/tests/Feature/Parsers/SortParserTest.php
@@ -6,127 +6,100 @@ namespace BlueBeetle\ApiToolkit\Tests\Feature\Parsers;
 
 use BlueBeetle\ApiToolkit\Parsers\SortParser;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\Product;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
 use Illuminate\Http\Request;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
 
-final class SortParserTest extends TestCase
-{
-    #[Test]
-    #[TestDox('it sorts ascending by default')]
-    public function it_sorts_ascending(): void
-    {
-        $parser = new SortParser(allowed: ['name']);
+it('sorts ascending by default', function () {
+    $parser = new SortParser(allowed: ['name']);
 
-        $request = Request::create('/', 'GET', ['sort' => 'name']);
-        $query = Product::query();
+    $request = Request::create('/', 'GET', ['sort' => 'name']);
+    $query = Product::query();
 
-        $parser->apply($request, $query);
+    $parser->apply($request, $query);
 
-        $orders = $query->getQuery()->orders ?? [];
-        $this->assertCount(1, $orders);
-        $this->assertSame('name', $orders[0]['column']);
-        $this->assertSame('asc', $orders[0]['direction']);
-    }
+    $orders = $query->getQuery()->orders ?? [];
+    expect($orders)->toHaveCount(1);
+    expect($orders[0]['column'])->toBe('name');
+    expect($orders[0]['direction'])->toBe('asc');
+});
 
-    #[Test]
-    #[TestDox('it sorts descending with dash prefix')]
-    public function it_sorts_descending(): void
-    {
-        $parser = new SortParser(allowed: ['created_at']);
+it('sorts descending with dash prefix', function () {
+    $parser = new SortParser(allowed: ['created_at']);
 
-        $request = Request::create('/', 'GET', ['sort' => '-created_at']);
-        $query = Product::query();
+    $request = Request::create('/', 'GET', ['sort' => '-created_at']);
+    $query = Product::query();
 
-        $parser->apply($request, $query);
+    $parser->apply($request, $query);
 
-        $orders = $query->getQuery()->orders ?? [];
-        $this->assertCount(1, $orders);
-        $this->assertSame('created_at', $orders[0]['column']);
-        $this->assertSame('desc', $orders[0]['direction']);
-    }
+    $orders = $query->getQuery()->orders ?? [];
+    expect($orders)->toHaveCount(1);
+    expect($orders[0]['column'])->toBe('created_at');
+    expect($orders[0]['direction'])->toBe('desc');
+});
 
-    #[Test]
-    #[TestDox('it handles multiple sort fields')]
-    public function it_handles_multiple_sorts(): void
-    {
-        $parser = new SortParser(allowed: ['name', 'created_at']);
+it('handles multiple sort fields', function () {
+    $parser = new SortParser(allowed: ['name', 'created_at']);
 
-        $request = Request::create('/', 'GET', ['sort' => '-created_at,name']);
-        $query = Product::query();
+    $request = Request::create('/', 'GET', ['sort' => '-created_at,name']);
+    $query = Product::query();
 
-        $parser->apply($request, $query);
+    $parser->apply($request, $query);
 
-        $orders = $query->getQuery()->orders ?? [];
-        $this->assertCount(2, $orders);
-        $this->assertSame('created_at', $orders[0]['column']);
-        $this->assertSame('desc', $orders[0]['direction']);
-        $this->assertSame('name', $orders[1]['column']);
-        $this->assertSame('asc', $orders[1]['direction']);
-    }
+    $orders = $query->getQuery()->orders ?? [];
+    expect($orders)->toHaveCount(2);
+    expect($orders[0]['column'])->toBe('created_at');
+    expect($orders[0]['direction'])->toBe('desc');
+    expect($orders[1]['column'])->toBe('name');
+    expect($orders[1]['direction'])->toBe('asc');
+});
 
-    #[Test]
-    #[TestDox('it ignores disallowed sort fields')]
-    public function it_ignores_disallowed_fields(): void
-    {
-        $parser = new SortParser(allowed: ['name']);
+it('ignores disallowed sort fields', function () {
+    $parser = new SortParser(allowed: ['name']);
 
-        $request = Request::create('/', 'GET', ['sort' => 'secret_column']);
-        $query = Product::query();
+    $request = Request::create('/', 'GET', ['sort' => 'secret_column']);
+    $query = Product::query();
 
-        $parser->apply($request, $query);
+    $parser->apply($request, $query);
 
-        $orders = $query->getQuery()->orders ?? [];
-        $this->assertEmpty($orders);
-    }
+    $orders = $query->getQuery()->orders ?? [];
+    expect($orders)->toBeEmpty();
+});
 
-    #[Test]
-    #[TestDox('it applies default sort when no sort parameter')]
-    public function it_applies_default_sort(): void
-    {
-        $parser = new SortParser(allowed: ['created_at'], default: '-created_at');
+it('applies default sort when no sort parameter', function () {
+    $parser = new SortParser(allowed: ['created_at'], default: '-created_at');
 
-        $request = Request::create('/');
-        $query = Product::query();
+    $request = Request::create('/');
+    $query = Product::query();
 
-        $parser->apply($request, $query);
+    $parser->apply($request, $query);
 
-        $orders = $query->getQuery()->orders ?? [];
-        $this->assertCount(1, $orders);
-        $this->assertSame('created_at', $orders[0]['column']);
-        $this->assertSame('desc', $orders[0]['direction']);
-    }
+    $orders = $query->getQuery()->orders ?? [];
+    expect($orders)->toHaveCount(1);
+    expect($orders[0]['column'])->toBe('created_at');
+    expect($orders[0]['direction'])->toBe('desc');
+});
 
-    #[Test]
-    #[TestDox('it does nothing when no sort and no default')]
-    public function it_does_nothing_without_sort(): void
-    {
-        $parser = new SortParser(allowed: ['name']);
+it('does nothing when no sort and no default', function () {
+    $parser = new SortParser(allowed: ['name']);
 
-        $request = Request::create('/');
-        $query = Product::query();
+    $request = Request::create('/');
+    $query = Product::query();
 
-        $parser->apply($request, $query);
+    $parser->apply($request, $query);
 
-        $orders = $query->getQuery()->orders ?? [];
-        $this->assertEmpty($orders);
-    }
+    $orders = $query->getQuery()->orders ?? [];
+    expect($orders)->toBeEmpty();
+});
 
-    #[Test]
-    #[TestDox('it skips empty sort fields from trailing commas')]
-    public function it_skips_empty_sort_fields(): void
-    {
-        $parser = new SortParser(allowed: ['name', 'code']);
+it('skips empty sort fields from trailing commas', function () {
+    $parser = new SortParser(allowed: ['name', 'code']);
 
-        $request = Request::create('/', 'GET', ['sort' => 'name,,code']);
-        $query = Product::query();
+    $request = Request::create('/', 'GET', ['sort' => 'name,,code']);
+    $query = Product::query();
 
-        $parser->apply($request, $query);
+    $parser->apply($request, $query);
 
-        $orders = $query->getQuery()->orders ?? [];
-        $this->assertCount(2, $orders);
-        $this->assertSame('name', $orders[0]['column']);
-        $this->assertSame('code', $orders[1]['column']);
-    }
-}
+    $orders = $query->getQuery()->orders ?? [];
+    expect($orders)->toHaveCount(2);
+    expect($orders[0]['column'])->toBe('name');
+    expect($orders[1]['column'])->toBe('code');
+});

--- a/tests/Feature/QueryBuilderTest.php
+++ b/tests/Feature/QueryBuilderTest.php
@@ -11,308 +11,253 @@ use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\Product;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\StubModel;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Resources\ProductResource;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Resources\StubQueryResource;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
 use Illuminate\Http\Request;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
 
-final class QueryBuilderTest extends TestCase
-{
-    #[Test]
-    #[TestDox('it creates a query builder from a model class')]
-    public function it_creates_from_model(): void
-    {
-        $request = Request::create('/');
+it('creates a query builder from a model class', function () {
+    $request = Request::create('/');
 
-        $builder = QueryBuilder::for(StubModel::class, $request);
+    $builder = QueryBuilder::for(StubModel::class, $request);
 
-        $this->assertInstanceOf(QueryBuilder::class, $builder);
-    }
+    expect($builder)->toBeInstanceOf(QueryBuilder::class);
+});
 
-    #[Test]
-    #[TestDox('it creates a query builder from an existing builder')]
-    public function it_creates_from_builder(): void
-    {
-        $request = Request::create('/');
-        $eloquentBuilder = StubModel::query();
+it('creates a query builder from an existing builder', function () {
+    $request = Request::create('/');
+    $eloquentBuilder = StubModel::query();
 
-        $builder = QueryBuilder::for($eloquentBuilder, $request);
+    $builder = QueryBuilder::for($eloquentBuilder, $request);
 
-        $this->assertInstanceOf(QueryBuilder::class, $builder);
-    }
+    expect($builder)->toBeInstanceOf(QueryBuilder::class);
+});
 
-    #[Test]
-    #[TestDox('it applies filters from resource')]
-    public function it_applies_filters_from_resource(): void
-    {
-        $request = Request::create('/', 'GET', ['filter' => ['name' => 'Widget']]);
+it('applies filters from resource', function () {
+    $request = Request::create('/', 'GET', ['filter' => ['name' => 'Widget']]);
 
-        $builder = QueryBuilder::for(StubModel::class, $request)
-            ->fromResource(StubQueryResource::class)
-        ;
+    $builder = QueryBuilder::for(StubModel::class, $request)
+        ->fromResource(StubQueryResource::class)
+    ;
 
-        $query = $builder->apply()->getQuery();
-        $sql = $query->toSql();
+    $query = $builder->apply()->getQuery();
+    $sql = $query->toSql();
 
-        // The PartialFilter adds a LIKE clause
-        $this->assertStringContainsString('like', mb_strtolower($sql));
-    }
+    expect(mb_strtolower($sql))->toContain('like');
+});
 
-    #[Test]
-    #[TestDox('it overrides resource filters with explicit filters')]
-    public function it_overrides_filters(): void
-    {
-        $request = Request::create('/', 'GET', ['filter' => ['name' => 'Widget']]);
+it('overrides resource filters with explicit filters', function () {
+    $request = Request::create('/', 'GET', ['filter' => ['name' => 'Widget']]);
 
-        $builder = QueryBuilder::for(StubModel::class, $request)
-            ->fromResource(StubQueryResource::class)
-            ->allowedFilters(['name' => new ExactFilter()])
-        ;
+    $builder = QueryBuilder::for(StubModel::class, $request)
+        ->fromResource(StubQueryResource::class)
+        ->allowedFilters(['name' => new ExactFilter()])
+    ;
 
-        $query = $builder->apply()->getQuery();
-        $sql = $query->toSql();
+    $query = $builder->apply()->getQuery();
+    $sql = $query->toSql();
 
-        // ExactFilter uses = instead of LIKE
-        $this->assertStringNotContainsString('like', mb_strtolower($sql));
-    }
+    expect(mb_strtolower($sql))->not->toContain('like');
+});
 
-    #[Test]
-    #[TestDox('it applies sorts from resource')]
-    public function it_applies_sorts_from_resource(): void
-    {
-        $request = Request::create('/');
+it('applies sorts from resource', function () {
+    $request = Request::create('/');
 
-        $builder = QueryBuilder::for(StubModel::class, $request)
-            ->fromResource(StubQueryResource::class)
-        ;
+    $builder = QueryBuilder::for(StubModel::class, $request)
+        ->fromResource(StubQueryResource::class)
+    ;
 
-        $query = $builder->apply()->getQuery();
+    $query = $builder->apply()->getQuery();
 
-        // Default sort should be applied
-        $orders = $query->getQuery()->orders ?? [];
-        $this->assertNotEmpty($orders);
-        $this->assertSame('created_at', $orders[0]['column']);
-        $this->assertSame('desc', $orders[0]['direction']);
-    }
+    $orders = $query->getQuery()->orders ?? [];
+    expect($orders)->not->toBeEmpty();
+    expect($orders[0]['column'])->toBe('created_at');
+    expect($orders[0]['direction'])->toBe('desc');
+});
 
-    #[Test]
-    #[TestDox('it overrides default sort')]
-    public function it_overrides_default_sort(): void
-    {
-        $request = Request::create('/');
+it('overrides default sort', function () {
+    $request = Request::create('/');
 
-        $builder = QueryBuilder::for(StubModel::class, $request)
-            ->fromResource(StubQueryResource::class)
-            ->defaultSort('name')
-        ;
+    $builder = QueryBuilder::for(StubModel::class, $request)
+        ->fromResource(StubQueryResource::class)
+        ->defaultSort('name')
+    ;
 
-        $query = $builder->apply()->getQuery();
+    $query = $builder->apply()->getQuery();
 
-        $orders = $query->getQuery()->orders ?? [];
-        $this->assertNotEmpty($orders);
-        $this->assertSame('name', $orders[0]['column']);
-        $this->assertSame('asc', $orders[0]['direction']);
-    }
+    $orders = $query->getQuery()->orders ?? [];
+    expect($orders)->not->toBeEmpty();
+    expect($orders[0]['column'])->toBe('name');
+    expect($orders[0]['direction'])->toBe('asc');
+});
 
-    #[Test]
-    #[TestDox('it applies includes from request')]
-    public function it_applies_includes(): void
-    {
-        $request = Request::create('/', 'GET', ['include' => 'category']);
+it('applies includes from request', function () {
+    $request = Request::create('/', 'GET', ['include' => 'category']);
 
-        $builder = QueryBuilder::for(StubModel::class, $request)
-            ->fromResource(StubQueryResource::class)
-        ;
+    $builder = QueryBuilder::for(StubModel::class, $request)
+        ->fromResource(StubQueryResource::class)
+    ;
 
-        $query = $builder->apply()->getQuery();
+    $query = $builder->apply()->getQuery();
 
-        $eagerLoads = $query->getEagerLoads();
-        $this->assertArrayHasKey('category', $eagerLoads);
-    }
+    $eagerLoads = $query->getEagerLoads();
+    expect($eagerLoads)->toHaveKey('category');
+});
 
-    #[Test]
-    #[TestDox('it works without a resource')]
-    public function it_works_without_resource(): void
-    {
-        $request = Request::create('/', 'GET', ['filter' => ['status' => 'active']]);
+it('works without a resource', function () {
+    $request = Request::create('/', 'GET', ['filter' => ['status' => 'active']]);
 
-        $builder = QueryBuilder::for(StubModel::class, $request)
-            ->allowedFilters(['status' => new ExactFilter()])
-            ->allowedSorts(['name', 'created_at'])
-            ->defaultSort('-created_at')
-        ;
+    $builder = QueryBuilder::for(StubModel::class, $request)
+        ->allowedFilters(['status' => new ExactFilter()])
+        ->allowedSorts(['name', 'created_at'])
+        ->defaultSort('-created_at')
+    ;
 
-        $query = $builder->apply()->getQuery();
-        $sql = $query->toSql();
+    $query = $builder->apply()->getQuery();
+    $sql = $query->toSql();
 
-        $this->assertStringContainsString('status', $sql);
-    }
+    expect($sql)->toContain('status');
+});
 
-    #[Test]
-    #[TestDox('it ignores disallowed includes')]
-    public function it_ignores_disallowed_includes(): void
-    {
-        $request = Request::create('/', 'GET', ['include' => 'category,secret']);
+it('ignores disallowed includes', function () {
+    $request = Request::create('/', 'GET', ['include' => 'category,secret']);
 
-        $builder = QueryBuilder::for(StubModel::class, $request)
-            ->allowedIncludes(['category'])
-        ;
+    $builder = QueryBuilder::for(StubModel::class, $request)
+        ->allowedIncludes(['category'])
+    ;
 
-        $query = $builder->apply()->getQuery();
+    $query = $builder->apply()->getQuery();
 
-        $eagerLoads = $query->getEagerLoads();
-        $this->assertArrayHasKey('category', $eagerLoads);
-        $this->assertArrayNotHasKey('secret', $eagerLoads);
-    }
+    $eagerLoads = $query->getEagerLoads();
+    expect($eagerLoads)->toHaveKey('category');
+    expect($eagerLoads)->not->toHaveKey('secret');
+});
 
-    #[Test]
-    #[TestDox('it does nothing with no configuration')]
-    public function it_does_nothing_bare(): void
-    {
-        $request = Request::create('/', 'GET', [
-            'filter' => ['status' => 'active'],
-            'sort' => 'name',
-            'include' => 'category',
-        ]);
+it('does nothing with no configuration', function () {
+    $request = Request::create('/', 'GET', [
+        'filter' => ['status' => 'active'],
+        'sort' => 'name',
+        'include' => 'category',
+    ]);
 
-        $builder = QueryBuilder::for(StubModel::class, $request);
-        $query = $builder->getQuery();
+    $builder = QueryBuilder::for(StubModel::class, $request);
+    $query = $builder->getQuery();
 
-        // No filters, sorts, or includes applied (getQuery returns raw builder)
-        $this->assertStringNotContainsString('status', $query->toSql());
-        $this->assertEmpty($query->getQuery()->orders ?? []);
-        $this->assertEmpty($query->getEagerLoads());
-    }
+    expect($query->toSql())->not->toContain('status');
+    expect($query->getQuery()->orders ?? [])->toBeEmpty();
+    expect($query->getEagerLoads())->toBeEmpty();
+});
 
-    #[Test]
-    #[TestDox('it returns a SuccessResponse from paginate')]
-    public function it_paginates(): void
-    {
-        Product::create([
-            'public_id' => 'prod-1',
-            'name' => 'Widget',
-            'code' => 'W01',
-            'price_in_cents' => 1000,
-            'featured' => false,
-        ]);
+it('returns a SuccessResponse from paginate', function () {
+    Product::create([
+        'public_id' => 'prod-1',
+        'name' => 'Widget',
+        'code' => 'W01',
+        'price_in_cents' => 1000,
+        'featured' => false,
+    ]);
 
-        $request = Request::create('/', 'GET', ['page' => ['size' => 10]]);
+    $request = Request::create('/', 'GET', ['page' => ['size' => 10]]);
 
-        $result = QueryBuilder::for(Product::class, $request)
-            ->fromResource(ProductResource::class)
-            ->paginate()
-        ;
+    $result = QueryBuilder::for(Product::class, $request)
+        ->fromResource(ProductResource::class)
+        ->paginate()
+    ;
 
-        $this->assertInstanceOf(SuccessResponse::class, $result);
+    expect($result)->toBeInstanceOf(SuccessResponse::class);
 
-        $array = $result->toArray();
-        $this->assertArrayHasKey('data', $array);
-        $this->assertArrayHasKey('meta', $array);
-        $this->assertArrayHasKey('links', $array);
-    }
+    $array = $result->toArray();
+    expect($array)->toHaveKey('data');
+    expect($array)->toHaveKey('meta');
+    expect($array)->toHaveKey('links');
+});
 
-    #[Test]
-    #[TestDox('it returns a SuccessResponse from cursorPaginate')]
-    public function it_cursor_paginates(): void
-    {
-        Product::create([
-            'public_id' => 'prod-1',
-            'name' => 'Widget',
-            'code' => 'W01',
-            'price_in_cents' => 1000,
-            'featured' => false,
-        ]);
+it('returns a SuccessResponse from cursorPaginate', function () {
+    Product::create([
+        'public_id' => 'prod-1',
+        'name' => 'Widget',
+        'code' => 'W01',
+        'price_in_cents' => 1000,
+        'featured' => false,
+    ]);
 
-        $request = Request::create('/', 'GET', ['page' => ['size' => 10]]);
+    $request = Request::create('/', 'GET', ['page' => ['size' => 10]]);
 
-        $result = QueryBuilder::for(Product::class, $request)
-            ->fromResource(ProductResource::class)
-            ->cursorPaginate()
-        ;
+    $result = QueryBuilder::for(Product::class, $request)
+        ->fromResource(ProductResource::class)
+        ->cursorPaginate()
+    ;
 
-        $this->assertInstanceOf(SuccessResponse::class, $result);
+    expect($result)->toBeInstanceOf(SuccessResponse::class);
 
-        $array = $result->toArray();
-        $this->assertArrayHasKey('data', $array);
-        $this->assertArrayHasKey('meta', $array);
-    }
+    $array = $result->toArray();
+    expect($array)->toHaveKey('data');
+    expect($array)->toHaveKey('meta');
+});
 
-    #[Test]
-    #[TestDox('it returns a SuccessResponse from get')]
-    public function it_gets(): void
-    {
-        Product::create([
-            'public_id' => 'prod-1',
-            'name' => 'Widget',
-            'code' => 'W01',
-            'price_in_cents' => 1000,
-            'featured' => false,
-        ]);
+it('returns a SuccessResponse from get', function () {
+    Product::create([
+        'public_id' => 'prod-1',
+        'name' => 'Widget',
+        'code' => 'W01',
+        'price_in_cents' => 1000,
+        'featured' => false,
+    ]);
 
-        $request = Request::create('/');
+    $request = Request::create('/');
 
-        $result = QueryBuilder::for(Product::class, $request)
-            ->fromResource(ProductResource::class)
-            ->get()
-        ;
+    $result = QueryBuilder::for(Product::class, $request)
+        ->fromResource(ProductResource::class)
+        ->get()
+    ;
 
-        $this->assertInstanceOf(SuccessResponse::class, $result);
+    expect($result)->toBeInstanceOf(SuccessResponse::class);
 
-        $array = $result->toArray();
-        $this->assertArrayHasKey('data', $array);
-    }
+    $array = $result->toArray();
+    expect($array)->toHaveKey('data');
+});
 
-    #[Test]
-    #[TestDox('apply returns the builder for further chaining')]
-    public function it_applies_and_returns_builder(): void
-    {
-        $request = Request::create('/', 'GET', ['filter' => ['status' => 'active']]);
+it('returns the builder for further chaining from apply', function () {
+    $request = Request::create('/', 'GET', ['filter' => ['status' => 'active']]);
 
-        $builder = QueryBuilder::for(StubModel::class, $request)
-            ->allowedFilters(['status' => new ExactFilter()])
-            ->apply()
-        ;
+    $builder = QueryBuilder::for(StubModel::class, $request)
+        ->allowedFilters(['status' => new ExactFilter()])
+        ->apply()
+    ;
 
-        $this->assertInstanceOf(QueryBuilder::class, $builder);
+    expect($builder)->toBeInstanceOf(QueryBuilder::class);
 
-        $query = $builder->getQuery();
-        $this->assertStringContainsString('status', $query->toSql());
-    }
+    $query = $builder->getQuery();
+    expect($query->toSql())->toContain('status');
+});
 
-    #[Test]
-    #[TestDox('paginate applies filters and sorts before paginating')]
-    public function it_applies_filters_before_paginating(): void
-    {
-        Product::create([
-            'public_id' => 'prod-1',
-            'name' => 'Widget',
-            'code' => 'W01',
-            'price_in_cents' => 1000,
-            'featured' => false,
-            'status' => 'active',
-        ]);
+it('applies filters and sorts before paginating', function () {
+    Product::create([
+        'public_id' => 'prod-1',
+        'name' => 'Widget',
+        'code' => 'W01',
+        'price_in_cents' => 1000,
+        'featured' => false,
+        'status' => 'active',
+    ]);
 
-        Product::create([
-            'public_id' => 'prod-2',
-            'name' => 'Gadget',
-            'code' => 'G01',
-            'price_in_cents' => 2000,
-            'featured' => false,
-            'status' => 'archived',
-        ]);
+    Product::create([
+        'public_id' => 'prod-2',
+        'name' => 'Gadget',
+        'code' => 'G01',
+        'price_in_cents' => 2000,
+        'featured' => false,
+        'status' => 'archived',
+    ]);
 
-        $request = Request::create('/', 'GET', [
-            'filter' => ['status' => 'active'],
-            'page' => ['size' => 10],
-        ]);
+    $request = Request::create('/', 'GET', [
+        'filter' => ['status' => 'active'],
+        'page' => ['size' => 10],
+    ]);
 
-        $result = QueryBuilder::for(Product::class, $request)
-            ->fromResource(ProductResource::class)
-            ->allowedFilters(['status' => new ExactFilter()])
-            ->paginate()
-        ;
+    $result = QueryBuilder::for(Product::class, $request)
+        ->fromResource(ProductResource::class)
+        ->allowedFilters(['status' => new ExactFilter()])
+        ->paginate()
+    ;
 
-        $array = $result->toArray();
-        $this->assertCount(1, $array['data']);
-    }
-}
+    $array = $result->toArray();
+    expect($array['data'])->toHaveCount(1);
+});

--- a/tests/Feature/Resources/ResourceCollectionTest.php
+++ b/tests/Feature/Resources/ResourceCollectionTest.php
@@ -8,172 +8,143 @@ use BlueBeetle\ApiToolkit\Resources\ResourceCollection;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\Product;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Resources\ProductResource;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Resources\StubResource;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
 use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Collection;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
 use stdClass;
 
-final class ResourceCollectionTest extends TestCase
+function makeItem(string $id, string $name): stdClass
 {
-    #[Test]
-    #[TestDox('it serializes a collection of items')]
-    public function it_serializes_collection(): void
-    {
-        $items = Collection::make([
-            $this->makeItem('1', 'Widget'),
-            $this->makeItem('2', 'Gadget'),
-        ]);
+    $item = new stdClass();
+    $item->id = $id;
+    $item->name = $name;
 
-        $collection = new ResourceCollection($items, StubResource::class);
-        $result = $collection->toArray();
-
-        $this->assertCount(2, $result['data']);
-        $this->assertSame('items', $result['data'][0]['type']);
-        $this->assertSame('1', $result['data'][0]['id']);
-        $this->assertSame('Widget', $result['data'][0]['attributes']['name']);
-        $this->assertSame('2', $result['data'][1]['id']);
-    }
-
-    #[Test]
-    #[TestDox('it includes pagination meta and links for offset pagination')]
-    public function it_includes_offset_pagination(): void
-    {
-        $items = [
-            $this->makeItem('1', 'Widget'),
-            $this->makeItem('2', 'Gadget'),
-        ];
-
-        $paginator = new LengthAwarePaginator(
-            items: $items,
-            total: 50,
-            perPage: 20,
-            currentPage: 2,
-        );
-
-        $collection = new ResourceCollection($paginator, StubResource::class);
-        $result = $collection->toArray();
-
-        $this->assertCount(2, $result['data']);
-        $this->assertSame(2, $result['meta']['page']['currentPage']);
-        $this->assertSame(3, $result['meta']['page']['lastPage']);
-        $this->assertSame(20, $result['meta']['page']['perPage']);
-        $this->assertSame(50, $result['meta']['page']['total']);
-        $this->assertArrayHasKey('first', $result['links']);
-        $this->assertArrayHasKey('last', $result['links']);
-        $this->assertArrayHasKey('prev', $result['links']);
-        $this->assertArrayHasKey('next', $result['links']);
-    }
-
-    #[Test]
-    #[TestDox('it handles empty collections')]
-    public function it_handles_empty_collections(): void
-    {
-        $collection = new ResourceCollection(Collection::make(), StubResource::class);
-        $result = $collection->toArray();
-
-        $this->assertSame([], $result['data']);
-        $this->assertArrayNotHasKey('meta', $result);
-    }
-
-    #[Test]
-    #[TestDox('it handles arrays')]
-    public function it_handles_arrays(): void
-    {
-        $items = [
-            $this->makeItem('1', 'Widget'),
-        ];
-
-        $collection = new ResourceCollection($items, StubResource::class);
-        $result = $collection->toArray();
-
-        $this->assertCount(1, $result['data']);
-        $this->assertSame('1', $result['data'][0]['id']);
-    }
-
-    #[Test]
-    #[TestDox('it includes cursor pagination meta and links')]
-    public function it_includes_cursor_pagination(): void
-    {
-        $items = [
-            $this->makeItem('1', 'Widget'),
-            $this->makeItem('2', 'Gadget'),
-        ];
-
-        $paginator = new CursorPaginator(
-            items: $items,
-            perPage: 2,
-            cursor: null,
-            options: ['parameters' => ['cursor']],
-        );
-
-        $collection = new ResourceCollection($paginator, StubResource::class);
-        $result = $collection->toArray();
-
-        $this->assertCount(2, $result['data']);
-        $this->assertArrayHasKey('page', $result['meta']);
-        $this->assertSame(2, $result['meta']['page']['perPage']);
-        $this->assertArrayHasKey('hasMore', $result['meta']['page']);
-        $this->assertArrayHasKey('prev', $result['links']);
-        $this->assertArrayHasKey('next', $result['links']);
-    }
-
-    #[Test]
-    #[TestDox('cursor pagination does not include offset-specific meta')]
-    public function it_excludes_offset_meta_for_cursor(): void
-    {
-        $items = [$this->makeItem('1', 'Widget')];
-
-        $paginator = new CursorPaginator(
-            items: $items,
-            perPage: 10,
-            cursor: null,
-        );
-
-        $collection = new ResourceCollection($paginator, StubResource::class);
-        $result = $collection->toArray();
-
-        $this->assertArrayNotHasKey('currentPage', $result['meta']['page']);
-        $this->assertArrayNotHasKey('lastPage', $result['meta']['page']);
-        $this->assertArrayNotHasKey('total', $result['meta']['page']);
-    }
-
-    #[Test]
-    #[TestDox('it skips null relations in included')]
-    public function it_skips_null_relations_in_included(): void
-    {
-        $product = Product::create([
-            'public_id' => 'prod-1',
-            'name' => 'Widget',
-            'code' => 'W01',
-            'price_in_cents' => 1000,
-            'featured' => false,
-            'category_id' => null,
-        ]);
-
-        // Load the category relation — it will be null
-        $product->load('category');
-
-        $collection = new ResourceCollection(
-            data: Collection::make([$product]),
-            resourceClass: ProductResource::class,
-        );
-
-        $result = $collection->toArray();
-
-        $this->assertCount(1, $result['data']);
-        // No included section since the only relation is null
-        $this->assertArrayNotHasKey('included', $result);
-    }
-
-    private function makeItem(string $id, string $name): stdClass
-    {
-        $item = new stdClass();
-        $item->id = $id;
-        $item->name = $name;
-
-        return $item;
-    }
+    return $item;
 }
+
+it('serializes a collection of items', function () {
+    $items = Collection::make([
+        makeItem('1', 'Widget'),
+        makeItem('2', 'Gadget'),
+    ]);
+
+    $collection = new ResourceCollection($items, StubResource::class);
+    $result = $collection->toArray();
+
+    expect($result['data'])->toHaveCount(2);
+    expect($result['data'][0]['type'])->toBe('items');
+    expect($result['data'][0]['id'])->toBe('1');
+    expect($result['data'][0]['attributes']['name'])->toBe('Widget');
+    expect($result['data'][1]['id'])->toBe('2');
+});
+
+it('includes pagination meta and links for offset pagination', function () {
+    $items = [
+        makeItem('1', 'Widget'),
+        makeItem('2', 'Gadget'),
+    ];
+
+    $paginator = new LengthAwarePaginator(
+        items: $items,
+        total: 50,
+        perPage: 20,
+        currentPage: 2,
+    );
+
+    $collection = new ResourceCollection($paginator, StubResource::class);
+    $result = $collection->toArray();
+
+    expect($result['data'])->toHaveCount(2);
+    expect($result['meta']['page']['currentPage'])->toBe(2);
+    expect($result['meta']['page']['lastPage'])->toBe(3);
+    expect($result['meta']['page']['perPage'])->toBe(20);
+    expect($result['meta']['page']['total'])->toBe(50);
+    expect($result['links'])->toHaveKey('first');
+    expect($result['links'])->toHaveKey('last');
+    expect($result['links'])->toHaveKey('prev');
+    expect($result['links'])->toHaveKey('next');
+});
+
+it('handles empty collections', function () {
+    $collection = new ResourceCollection(Collection::make(), StubResource::class);
+    $result = $collection->toArray();
+
+    expect($result['data'])->toBe([]);
+    expect($result)->not->toHaveKey('meta');
+});
+
+it('handles arrays', function () {
+    $items = [
+        makeItem('1', 'Widget'),
+    ];
+
+    $collection = new ResourceCollection($items, StubResource::class);
+    $result = $collection->toArray();
+
+    expect($result['data'])->toHaveCount(1);
+    expect($result['data'][0]['id'])->toBe('1');
+});
+
+it('includes cursor pagination meta and links', function () {
+    $items = [
+        makeItem('1', 'Widget'),
+        makeItem('2', 'Gadget'),
+    ];
+
+    $paginator = new CursorPaginator(
+        items: $items,
+        perPage: 2,
+        cursor: null,
+        options: ['parameters' => ['cursor']],
+    );
+
+    $collection = new ResourceCollection($paginator, StubResource::class);
+    $result = $collection->toArray();
+
+    expect($result['data'])->toHaveCount(2);
+    expect($result['meta'])->toHaveKey('page');
+    expect($result['meta']['page']['perPage'])->toBe(2);
+    expect($result['meta']['page'])->toHaveKey('hasMore');
+    expect($result['links'])->toHaveKey('prev');
+    expect($result['links'])->toHaveKey('next');
+});
+
+it('excludes offset-specific meta for cursor pagination', function () {
+    $items = [makeItem('1', 'Widget')];
+
+    $paginator = new CursorPaginator(
+        items: $items,
+        perPage: 10,
+        cursor: null,
+    );
+
+    $collection = new ResourceCollection($paginator, StubResource::class);
+    $result = $collection->toArray();
+
+    expect($result['meta']['page'])->not->toHaveKey('currentPage');
+    expect($result['meta']['page'])->not->toHaveKey('lastPage');
+    expect($result['meta']['page'])->not->toHaveKey('total');
+});
+
+it('skips null relations in included', function () {
+    $product = Product::create([
+        'public_id' => 'prod-1',
+        'name' => 'Widget',
+        'code' => 'W01',
+        'price_in_cents' => 1000,
+        'featured' => false,
+        'category_id' => null,
+    ]);
+
+    $product->load('category');
+
+    $collection = new ResourceCollection(
+        data: Collection::make([$product]),
+        resourceClass: ProductResource::class,
+    );
+
+    $result = $collection->toArray();
+
+    expect($result['data'])->toHaveCount(1);
+    expect($result)->not->toHaveKey('included');
+});

--- a/tests/Feature/Resources/ResourceTest.php
+++ b/tests/Feature/Resources/ResourceTest.php
@@ -7,380 +7,324 @@ namespace BlueBeetle\ApiToolkit\Tests\Feature\Resources;
 use BadMethodCallException;
 use BlueBeetle\ApiToolkit\Resources\Resource;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\Product;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
 use stdClass;
 
-final class ResourceTest extends TestCase
-{
-    #[Test]
-    #[TestDox('it serializes a model to JSON:API resource object')]
-    public function it_serializes_to_resource_object(): void
-    {
-        $resource = new class() extends Resource {
-            protected string $type = 'products';
-
-            public function attributes($model): array
-            {
-                return [
-                    'name' => $model->name,
-                    'code' => $model->code,
-                ];
-            }
-        };
-
-        $model = new stdClass();
-        $model->id = 'abc-123';
-        $model->name = 'Widget';
-        $model->code = 'W01';
-
-        $result = $resource->toArray($model);
-
-        $this->assertSame('products', $result['type']);
-        $this->assertSame('abc-123', $result['id']);
-        $this->assertSame('Widget', $result['attributes']['name']);
-        $this->assertSame('W01', $result['attributes']['code']);
-        $this->assertSame([], $result['relationships']);
-        $this->assertSame([], $result['links']);
-        $this->assertSame([], $result['meta']);
-    }
-
-    #[Test]
-    #[TestDox('it returns null when model is null')]
-    public function it_returns_null_for_null_model(): void
-    {
-        $resource = new class() extends Resource {
-            public function attributes($model): array
-            {
-                return [];
-            }
-        };
-
-        $this->assertNull($resource->toArray(null));
-    }
-
-    #[Test]
-    #[TestDox('it resolves id from public_id when available')]
-    public function it_resolves_id_from_public_id(): void
-    {
-        $resource = new class() extends Resource {
-            protected string $type = 'items';
-
-            public function attributes($model): array
-            {
-                return [];
-            }
-        };
-
-        $model = new stdClass();
-        $model->public_id = 'pub-456';
-
-        $result = $resource->toArray($model);
-
-        $this->assertSame('pub-456', $result['id']);
-    }
-
-    #[Test]
-    #[TestDox('it uses the static make method for quick transformation')]
-    public function it_uses_static_make(): void
-    {
-        $resourceClass = new class() extends Resource {
-            protected string $type = 'items';
-
-            public function attributes($model): array
-            {
-                return ['name' => $model->name];
-            }
-        };
-
-        $model = new stdClass();
-        $model->id = '1';
-        $model->name = 'Test';
-
-        $result = $resourceClass::make($model);
-
-        $this->assertSame('items', $result['type']);
-        $this->assertSame('Test', $result['attributes']['name']);
-    }
-
-    #[Test]
-    #[TestDox('it includes self link and meta when defined')]
-    public function it_includes_self_and_meta(): void
-    {
-        $resource = new class() extends Resource {
-            protected string $type = 'items';
-
-            public function attributes($model): array
-            {
-                return ['name' => $model->name];
-            }
-
-            public function self($model): string | null
-            {
-                return '/items/'.$model->id;
-            }
-
-            public function meta($model): array
-            {
-                return ['version' => 1];
-            }
-        };
-
-        $model = new stdClass();
-        $model->id = '42';
-        $model->name = 'Test';
-
-        $result = $resource->toArray($model);
-
-        $this->assertSame('/items/42', $result['links']['self']);
-        $this->assertSame(1, $result['meta']['version']);
-    }
-
-    #[Test]
-    #[TestDox('it derives type from class name when not set')]
-    public function it_derives_type_from_class_name(): void
-    {
-        $resource = new class() extends Resource {
-            public function attributes($model): array
-            {
-                return [];
-            }
-        };
-
-        $model = new stdClass();
-        $model->id = '1';
-
-        $result = $resource->toArray($model);
-
-        $this->assertSame('std-class', $result['type']);
-    }
-
-    #[Test]
-    #[TestDox('it merges self with additional links')]
-    public function it_merges_self_with_additional_links(): void
-    {
-        $resource = new class() extends Resource {
-            protected string $type = 'products';
-
-            public function attributes($model): array
-            {
-                return ['name' => $model->name];
-            }
-
-            public function self($model): string | null
-            {
-                return '/api/v1/products/'.$model->id;
-            }
-
-            public function links($model): array
-            {
-                return ['inventory' => '/api/v1/products/'.$model->id.'/inventory'];
-            }
-        };
-
-        $model = new stdClass();
-        $model->id = 'abc-123';
-        $model->name = 'Widget';
-
-        $result = $resource->toArray($model);
-
-        $this->assertSame('/api/v1/products/abc-123', $result['links']['self']);
-        $this->assertSame('/api/v1/products/abc-123/inventory', $result['links']['inventory']);
-    }
-
-    #[Test]
-    #[TestDox('it has no self link when self returns null')]
-    public function it_has_no_self_link_when_null(): void
-    {
-        $resource = new class() extends Resource {
-            protected string $type = 'items';
-
-            public function attributes($model): array
-            {
-                return [];
-            }
-        };
-
-        $model = new stdClass();
-        $model->id = '1';
-
-        $result = $resource->toArray($model);
-
-        $this->assertSame([], $result['links']);
-    }
-
-    #[Test]
-    #[TestDox('it has only additional links when self is not defined')]
-    public function it_has_only_additional_links(): void
-    {
-        $resource = new class() extends Resource {
-            protected string $type = 'items';
-
-            public function attributes($model): array
-            {
-                return [];
-            }
-
-            public function links($model): array
-            {
-                return ['related' => '/related/'.$model->id];
-            }
-        };
-
-        $model = new stdClass();
-        $model->id = '1';
-
-        $result = $resource->toArray($model);
-
-        $this->assertArrayNotHasKey('self', $result['links']);
-        $this->assertSame('/related/1', $result['links']['related']);
-    }
-
-    #[Test]
-    #[TestDox('it uses global ID resolver')]
-    public function it_uses_global_id_resolver(): void
-    {
-        Resource::resolveIdUsing(fn ($model) => 'custom-'.$model->id);
-
-        $resource = new class() extends Resource {
-            protected string $type = 'items';
-
-            public function attributes($model): array
-            {
-                return [];
-            }
-        };
-
-        $model = new stdClass();
-        $model->id = '42';
-
-        $result = $resource->toArray($model);
-
-        $this->assertSame('custom-42', $result['id']);
-
-        Resource::resetResolvers();
-    }
-
-    #[Test]
-    #[TestDox('it uses global type resolver')]
-    public function it_uses_global_type_resolver(): void
-    {
-        Resource::resolveTypeUsing(fn ($model) => 'custom-type');
-
-        $resource = new class() extends Resource {
-            public function attributes($model): array
-            {
-                return [];
-            }
-        };
-
-        $model = new stdClass();
-        $model->id = '1';
-
-        $result = $resource->toArray($model);
-
-        $this->assertSame('custom-type', $result['type']);
-
-        Resource::resetResolvers();
-    }
-
-    #[Test]
-    #[TestDox('explicit type property takes precedence over global resolver')]
-    public function explicit_type_takes_precedence(): void
-    {
-        Resource::resolveTypeUsing(fn ($model) => 'global-type');
-
-        $resource = new class() extends Resource {
-            protected string $type = 'explicit-type';
-
-            public function attributes($model): array
-            {
-                return [];
-            }
-        };
-
-        $model = new stdClass();
-        $model->id = '1';
-
-        $result = $resource->toArray($model);
-
-        $this->assertSame('explicit-type', $result['type']);
-
-        Resource::resetResolvers();
-    }
-
-    #[Test]
-    #[TestDox('reset resolvers restores default behavior')]
-    public function reset_resolvers_restores_defaults(): void
-    {
-        Resource::resolveIdUsing(fn ($model) => 'custom');
-        Resource::resetResolvers();
-
-        $resource = new class() extends Resource {
-            protected string $type = 'items';
-
-            public function attributes($model): array
-            {
-                return [];
-            }
-        };
-
-        $model = new stdClass();
-        $model->id = '99';
-
-        $result = $resource->toArray($model);
-
-        $this->assertSame('99', $result['id']);
-    }
-
-    #[Test]
-    #[TestDox('it throws when attributes method is not implemented')]
-    public function it_throws_without_attributes(): void
-    {
-        $this->expectException(BadMethodCallException::class);
-
-        $resource = new class() extends Resource {
-            protected string $type = 'items';
-        };
-
-        $model = new stdClass();
-        $model->id = '1';
-
-        $resource->toArray($model);
-    }
-
-    #[Test]
-    #[TestDox('it resolves type from model instance table name')]
-    public function it_resolves_type_from_model_table(): void
-    {
-        $resource = new class() extends Resource {
-            public function attributes($model): array
-            {
-                return [];
-            }
-        };
-
-        $model = new Product();
-        $model->id = 1;
-        $model->public_id = 'prod-1';
-
-        $result = $resource->toArray($model);
-
-        $this->assertSame('products', $result['type']);
-    }
-
-    #[Test]
-    #[TestDox('it returns empty type when no model and no type set')]
-    public function it_returns_empty_type(): void
-    {
-        $resource = new class() extends Resource {
-            public function attributes($model): array
-            {
-                return [];
-            }
-        };
-
-        $this->assertSame('', $resource->resolveType());
-    }
-}
+it('serializes a model to JSON:API resource object', function () {
+    $resource = new class() extends Resource {
+        protected string $type = 'products';
+
+        public function attributes($model): array
+        {
+            return [
+                'name' => $model->name,
+                'code' => $model->code,
+            ];
+        }
+    };
+
+    $model = new stdClass();
+    $model->id = 'abc-123';
+    $model->name = 'Widget';
+    $model->code = 'W01';
+
+    $result = $resource->toArray($model);
+
+    expect($result['type'])->toBe('products');
+    expect($result['id'])->toBe('abc-123');
+    expect($result['attributes']['name'])->toBe('Widget');
+    expect($result['attributes']['code'])->toBe('W01');
+    expect($result['relationships'])->toBe([]);
+    expect($result['links'])->toBe([]);
+    expect($result['meta'])->toBe([]);
+});
+
+it('returns null when model is null', function () {
+    $resource = new class() extends Resource {
+        public function attributes($model): array
+        {
+            return [];
+        }
+    };
+
+    expect($resource->toArray(null))->toBeNull();
+});
+
+it('resolves id from public_id when available', function () {
+    $resource = new class() extends Resource {
+        protected string $type = 'items';
+
+        public function attributes($model): array
+        {
+            return [];
+        }
+    };
+
+    $model = new stdClass();
+    $model->public_id = 'pub-456';
+
+    $result = $resource->toArray($model);
+
+    expect($result['id'])->toBe('pub-456');
+});
+
+it('uses the static make method for quick transformation', function () {
+    $resourceClass = new class() extends Resource {
+        protected string $type = 'items';
+
+        public function attributes($model): array
+        {
+            return ['name' => $model->name];
+        }
+    };
+
+    $model = new stdClass();
+    $model->id = '1';
+    $model->name = 'Test';
+
+    $result = $resourceClass::make($model);
+
+    expect($result['type'])->toBe('items');
+    expect($result['attributes']['name'])->toBe('Test');
+});
+
+it('includes self link and meta when defined', function () {
+    $resource = new class() extends Resource {
+        protected string $type = 'items';
+
+        public function attributes($model): array
+        {
+            return ['name' => $model->name];
+        }
+
+        public function self($model): string | null
+        {
+            return '/items/'.$model->id;
+        }
+
+        public function meta($model): array
+        {
+            return ['version' => 1];
+        }
+    };
+
+    $model = new stdClass();
+    $model->id = '42';
+    $model->name = 'Test';
+
+    $result = $resource->toArray($model);
+
+    expect($result['links']['self'])->toBe('/items/42');
+    expect($result['meta']['version'])->toBe(1);
+});
+
+it('derives type from class name when not set', function () {
+    $resource = new class() extends Resource {
+        public function attributes($model): array
+        {
+            return [];
+        }
+    };
+
+    $model = new stdClass();
+    $model->id = '1';
+
+    $result = $resource->toArray($model);
+
+    expect($result['type'])->toBe('std-class');
+});
+
+it('merges self with additional links', function () {
+    $resource = new class() extends Resource {
+        protected string $type = 'products';
+
+        public function attributes($model): array
+        {
+            return ['name' => $model->name];
+        }
+
+        public function self($model): string | null
+        {
+            return '/api/v1/products/'.$model->id;
+        }
+
+        public function links($model): array
+        {
+            return ['inventory' => '/api/v1/products/'.$model->id.'/inventory'];
+        }
+    };
+
+    $model = new stdClass();
+    $model->id = 'abc-123';
+    $model->name = 'Widget';
+
+    $result = $resource->toArray($model);
+
+    expect($result['links']['self'])->toBe('/api/v1/products/abc-123');
+    expect($result['links']['inventory'])->toBe('/api/v1/products/abc-123/inventory');
+});
+
+it('has no self link when self returns null', function () {
+    $resource = new class() extends Resource {
+        protected string $type = 'items';
+
+        public function attributes($model): array
+        {
+            return [];
+        }
+    };
+
+    $model = new stdClass();
+    $model->id = '1';
+
+    $result = $resource->toArray($model);
+
+    expect($result['links'])->toBe([]);
+});
+
+it('has only additional links when self is not defined', function () {
+    $resource = new class() extends Resource {
+        protected string $type = 'items';
+
+        public function attributes($model): array
+        {
+            return [];
+        }
+
+        public function links($model): array
+        {
+            return ['related' => '/related/'.$model->id];
+        }
+    };
+
+    $model = new stdClass();
+    $model->id = '1';
+
+    $result = $resource->toArray($model);
+
+    expect($result['links'])->not->toHaveKey('self');
+    expect($result['links']['related'])->toBe('/related/1');
+});
+
+it('uses global ID resolver', function () {
+    Resource::resolveIdUsing(fn ($model) => 'custom-'.$model->id);
+
+    $resource = new class() extends Resource {
+        protected string $type = 'items';
+
+        public function attributes($model): array
+        {
+            return [];
+        }
+    };
+
+    $model = new stdClass();
+    $model->id = '42';
+
+    $result = $resource->toArray($model);
+
+    expect($result['id'])->toBe('custom-42');
+
+    Resource::resetResolvers();
+});
+
+it('uses global type resolver', function () {
+    Resource::resolveTypeUsing(fn ($model) => 'custom-type');
+
+    $resource = new class() extends Resource {
+        public function attributes($model): array
+        {
+            return [];
+        }
+    };
+
+    $model = new stdClass();
+    $model->id = '1';
+
+    $result = $resource->toArray($model);
+
+    expect($result['type'])->toBe('custom-type');
+
+    Resource::resetResolvers();
+});
+
+it('gives precedence to explicit type property over global resolver', function () {
+    Resource::resolveTypeUsing(fn ($model) => 'global-type');
+
+    $resource = new class() extends Resource {
+        protected string $type = 'explicit-type';
+
+        public function attributes($model): array
+        {
+            return [];
+        }
+    };
+
+    $model = new stdClass();
+    $model->id = '1';
+
+    $result = $resource->toArray($model);
+
+    expect($result['type'])->toBe('explicit-type');
+
+    Resource::resetResolvers();
+});
+
+it('restores default behavior after reset resolvers', function () {
+    Resource::resolveIdUsing(fn ($model) => 'custom');
+    Resource::resetResolvers();
+
+    $resource = new class() extends Resource {
+        protected string $type = 'items';
+
+        public function attributes($model): array
+        {
+            return [];
+        }
+    };
+
+    $model = new stdClass();
+    $model->id = '99';
+
+    $result = $resource->toArray($model);
+
+    expect($result['id'])->toBe('99');
+});
+
+it('throws when attributes method is not implemented', function () {
+    $resource = new class() extends Resource {
+        protected string $type = 'items';
+    };
+
+    $model = new stdClass();
+    $model->id = '1';
+
+    $resource->toArray($model);
+})->throws(BadMethodCallException::class);
+
+it('resolves type from model instance table name', function () {
+    $resource = new class() extends Resource {
+        public function attributes($model): array
+        {
+            return [];
+        }
+    };
+
+    $model = new Product();
+    $model->id = 1;
+    $model->public_id = 'prod-1';
+
+    $result = $resource->toArray($model);
+
+    expect($result['type'])->toBe('products');
+});
+
+it('returns empty type when no model and no type set', function () {
+    $resource = new class() extends Resource {
+        public function attributes($model): array
+        {
+            return [];
+        }
+    };
+
+    expect($resource->resolveType())->toBe('');
+});

--- a/tests/Feature/Response/ResponseTest.php
+++ b/tests/Feature/Response/ResponseTest.php
@@ -6,272 +6,217 @@ namespace BlueBeetle\ApiToolkit\Tests\Feature\Response;
 
 use BlueBeetle\ApiToolkit\Http\Response;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Resources\StubItemResource;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
 use Illuminate\Http\Request;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
 use stdClass;
 
-final class ResponseTest extends TestCase
-{
-    #[Test]
-    #[TestDox('it creates a success response with a single resource')]
-    public function it_creates_success_response(): void
-    {
-        $response = new Response();
+it('creates a success response with a single resource', function () {
+    $response = new Response();
 
-        $model = new stdClass();
-        $model->id = '1';
-        $model->name = 'Widget';
+    $model = new stdClass();
+    $model->id = '1';
+    $model->name = 'Widget';
 
-        $result = $response->success($model, StubItemResource::class)->respond();
+    $result = $response->success($model, StubItemResource::class)->respond();
 
-        $this->assertSame(200, $result->getStatusCode());
-        $this->assertSame('application/vnd.api+json', $result->headers->get('Content-Type'));
+    expect($result->getStatusCode())->toBe(200);
+    expect($result->headers->get('Content-Type'))->toBe('application/vnd.api+json');
 
-        $data = json_decode($result->getContent(), true);
+    $data = json_decode($result->getContent(), true);
 
-        $this->assertSame('items', $data['data']['type']);
-        $this->assertSame('1', $data['data']['id']);
-        $this->assertSame('Widget', $data['data']['attributes']['name']);
-    }
+    expect($data['data']['type'])->toBe('items');
+    expect($data['data']['id'])->toBe('1');
+    expect($data['data']['attributes']['name'])->toBe('Widget');
+});
 
-    #[Test]
-    #[TestDox('it creates a success response with null data')]
-    public function it_creates_success_with_null(): void
-    {
-        $response = new Response();
+it('creates a success response with null data', function () {
+    $response = new Response();
 
-        $result = $response->success()->respond();
-        $data = json_decode($result->getContent(), true);
+    $result = $response->success()->respond();
+    $data = json_decode($result->getContent(), true);
 
-        $this->assertNull($data['data']);
-    }
+    expect($data['data'])->toBeNull();
+});
 
-    #[Test]
-    #[TestDox('it creates a success response with custom status code')]
-    public function it_creates_success_with_custom_status(): void
-    {
-        $response = new Response();
+it('creates a success response with custom status code', function () {
+    $response = new Response();
 
-        $model = new stdClass();
-        $model->id = '1';
-        $model->name = 'Created';
+    $model = new stdClass();
+    $model->id = '1';
+    $model->name = 'Created';
 
-        $result = $response->success($model, StubItemResource::class)->respond(201);
+    $result = $response->success($model, StubItemResource::class)->respond(201);
 
-        $this->assertSame(201, $result->getStatusCode());
-    }
+    expect($result->getStatusCode())->toBe(201);
+});
 
-    #[Test]
-    #[TestDox('it creates a success response with extra meta')]
-    public function it_creates_success_with_meta(): void
-    {
-        $response = new Response();
+it('creates a success response with extra meta', function () {
+    $response = new Response();
 
-        $model = new stdClass();
-        $model->id = '1';
-        $model->name = 'Widget';
+    $model = new stdClass();
+    $model->id = '1';
+    $model->name = 'Widget';
 
-        $result = $response
-            ->success($model, StubItemResource::class)
-            ->meta(['request_id' => 'req-abc'])
-            ->respond()
-        ;
+    $result = $response
+        ->success($model, StubItemResource::class)
+        ->meta(['request_id' => 'req-abc'])
+        ->respond()
+    ;
 
-        $data = json_decode($result->getContent(), true);
+    $data = json_decode($result->getContent(), true);
 
-        $this->assertSame('req-abc', $data['meta']['request_id']);
-    }
+    expect($data['meta']['request_id'])->toBe('req-abc');
+});
 
-    #[Test]
-    #[TestDox('it creates a success response with a collection')]
-    public function it_creates_success_with_collection(): void
-    {
-        $response = new Response();
+it('creates a success response with a collection', function () {
+    $response = new Response();
 
-        $items = [
-            (object) ['id' => '1', 'name' => 'Widget'],
-            (object) ['id' => '2', 'name' => 'Gadget'],
-        ];
+    $items = [
+        (object) ['id' => '1', 'name' => 'Widget'],
+        (object) ['id' => '2', 'name' => 'Gadget'],
+    ];
 
-        $result = $response->success($items, StubItemResource::class)->respond();
-        $data = json_decode($result->getContent(), true);
+    $result = $response->success($items, StubItemResource::class)->respond();
+    $data = json_decode($result->getContent(), true);
 
-        $this->assertCount(2, $data['data']);
-        $this->assertSame('Widget', $data['data'][0]['attributes']['name']);
-        $this->assertSame('Gadget', $data['data'][1]['attributes']['name']);
-    }
+    expect($data['data'])->toHaveCount(2);
+    expect($data['data'][0]['attributes']['name'])->toBe('Widget');
+    expect($data['data'][1]['attributes']['name'])->toBe('Gadget');
+});
 
-    #[Test]
-    #[TestDox('it creates an error response')]
-    public function it_creates_error_response(): void
-    {
-        $response = new Response();
+it('creates an error response', function () {
+    $response = new Response();
 
-        $result = $response->error('Bad Request', 'Missing required field: name', 400)->respond();
+    $result = $response->error('Bad Request', 'Missing required field: name', 400)->respond();
 
-        $this->assertSame(400, $result->getStatusCode());
-        $this->assertSame('application/vnd.api+json', $result->headers->get('Content-Type'));
+    expect($result->getStatusCode())->toBe(400);
+    expect($result->headers->get('Content-Type'))->toBe('application/vnd.api+json');
 
-        $data = json_decode($result->getContent(), true);
+    $data = json_decode($result->getContent(), true);
 
-        $this->assertSame('400', $data['errors'][0]['status']);
-        $this->assertSame('Bad Request', $data['errors'][0]['title']);
-        $this->assertSame('Missing required field: name', $data['errors'][0]['detail']);
-    }
+    expect($data['errors'][0]['status'])->toBe('400');
+    expect($data['errors'][0]['title'])->toBe('Bad Request');
+    expect($data['errors'][0]['detail'])->toBe('Missing required field: name');
+});
 
-    #[Test]
-    #[TestDox('it creates an error response with code and source')]
-    public function it_creates_error_with_code_and_source(): void
-    {
-        $response = new Response();
+it('creates an error response with code and source', function () {
+    $response = new Response();
 
-        $result = $response
-            ->error('Validation Error', 'Name is required', 422)
-            ->code('validation_error')
-            ->source(['pointer' => '/data/attributes/name'])
-            ->respond()
-        ;
+    $result = $response
+        ->error('Validation Error', 'Name is required', 422)
+        ->code('validation_error')
+        ->source(['pointer' => '/data/attributes/name'])
+        ->respond()
+    ;
 
-        $data = json_decode($result->getContent(), true);
+    $data = json_decode($result->getContent(), true);
 
-        $this->assertSame('validation_error', $data['errors'][0]['code']);
-        $this->assertSame('/data/attributes/name', $data['errors'][0]['source']['pointer']);
-    }
+    expect($data['errors'][0]['code'])->toBe('validation_error');
+    expect($data['errors'][0]['source']['pointer'])->toBe('/data/attributes/name');
+});
 
-    #[Test]
-    #[TestDox('it creates a success response without a resource class')]
-    public function it_creates_success_without_resource(): void
-    {
-        $response = new Response();
+it('creates a success response without a resource class', function () {
+    $response = new Response();
 
-        $result = $response->success(['raw' => 'data'])->respond();
-        $data = json_decode($result->getContent(), true);
+    $result = $response->success(['raw' => 'data'])->respond();
+    $data = json_decode($result->getContent(), true);
 
-        $this->assertSame(['raw' => 'data'], $data['data']);
-    }
+    expect($data['data'])->toBe(['raw' => 'data']);
+});
 
-    #[Test]
-    #[TestDox('it creates a success response with links')]
-    public function it_creates_success_with_links(): void
-    {
-        $response = new Response();
+it('creates a success response with links', function () {
+    $response = new Response();
 
-        $model = new stdClass();
-        $model->id = '1';
-        $model->name = 'Widget';
+    $model = new stdClass();
+    $model->id = '1';
+    $model->name = 'Widget';
 
-        $result = $response
-            ->success($model, StubItemResource::class)
-            ->links(['self' => '/api/v1/items/1'])
-            ->respond()
-        ;
+    $result = $response
+        ->success($model, StubItemResource::class)
+        ->links(['self' => '/api/v1/items/1'])
+        ->respond()
+    ;
 
-        $data = json_decode($result->getContent(), true);
+    $data = json_decode($result->getContent(), true);
 
-        $this->assertSame('/api/v1/items/1', $data['links']['self']);
-    }
+    expect($data['links']['self'])->toBe('/api/v1/items/1');
+});
 
-    #[Test]
-    #[TestDox('it creates a success response with custom headers')]
-    public function it_creates_success_with_custom_headers(): void
-    {
-        $response = new Response();
+it('creates a success response with custom headers', function () {
+    $response = new Response();
 
-        $result = $response->success()->respond(200, ['X-Request-Id' => 'req-123']);
+    $result = $response->success()->respond(200, ['X-Request-Id' => 'req-123']);
 
-        $this->assertSame('req-123', $result->headers->get('X-Request-Id'));
-        $this->assertSame('application/vnd.api+json', $result->headers->get('Content-Type'));
-    }
+    expect($result->headers->get('X-Request-Id'))->toBe('req-123');
+    expect($result->headers->get('Content-Type'))->toBe('application/vnd.api+json');
+});
 
-    #[Test]
-    #[TestDox('it creates an error response with meta')]
-    public function it_creates_error_with_meta(): void
-    {
-        $response = new Response();
+it('creates an error response with meta', function () {
+    $response = new Response();
 
-        $result = $response
-            ->error('Bad Request', 'Something went wrong', 400)
-            ->meta(['request_id' => 'req-abc'])
-            ->respond()
-        ;
+    $result = $response
+        ->error('Bad Request', 'Something went wrong', 400)
+        ->meta(['request_id' => 'req-abc'])
+        ->respond()
+    ;
 
-        $data = json_decode($result->getContent(), true);
+    $data = json_decode($result->getContent(), true);
 
-        $this->assertSame('req-abc', $data['errors'][0]['meta']['request_id']);
-    }
+    expect($data['errors'][0]['meta']['request_id'])->toBe('req-abc');
+});
 
-    #[Test]
-    #[TestDox('it creates an error response with custom headers')]
-    public function it_creates_error_with_custom_headers(): void
-    {
-        $response = new Response();
+it('creates an error response with custom headers', function () {
+    $response = new Response();
 
-        $result = $response
-            ->error('Too Many Requests', 'Rate limit exceeded', 429)
-            ->respond(null, ['Retry-After' => '60'])
-        ;
+    $result = $response
+        ->error('Too Many Requests', 'Rate limit exceeded', 429)
+        ->respond(null, ['Retry-After' => '60'])
+    ;
 
-        $this->assertSame(429, $result->getStatusCode());
-        $this->assertSame('60', $result->headers->get('Retry-After'));
-    }
+    expect($result->getStatusCode())->toBe(429);
+    expect($result->headers->get('Retry-After'))->toBe('60');
+});
 
-    #[Test]
-    #[TestDox('it creates an error response with status override')]
-    public function it_creates_error_with_status_override(): void
-    {
-        $response = new Response();
+it('creates an error response with status override', function () {
+    $response = new Response();
 
-        $result = $response
-            ->error('Error', 'detail', 400)
-            ->respond(503)
-        ;
+    $result = $response
+        ->error('Error', 'detail', 400)
+        ->respond(503)
+    ;
 
-        $this->assertSame(503, $result->getStatusCode());
+    expect($result->getStatusCode())->toBe(503);
 
-        $data = json_decode($result->getContent(), true);
-        // toArray still uses the original status
-        $this->assertSame('400', $data['errors'][0]['status']);
-    }
+    $data = json_decode($result->getContent(), true);
+    expect($data['errors'][0]['status'])->toBe('400');
+});
 
-    #[Test]
-    #[TestDox('it implements Responsable for success response')]
-    public function it_implements_responsable_for_success(): void
-    {
-        $response = new Response();
+it('implements Responsable for success response', function () {
+    $response = new Response();
 
-        $successResponse = $response->success(['test' => true]);
-        $result = $successResponse->toResponse(Request::create('/'));
+    $successResponse = $response->success(['test' => true]);
+    $result = $successResponse->toResponse(Request::create('/'));
 
-        $this->assertSame(200, $result->getStatusCode());
-    }
+    expect($result->getStatusCode())->toBe(200);
+});
 
-    #[Test]
-    #[TestDox('it implements Responsable for error response')]
-    public function it_implements_responsable_for_error(): void
-    {
-        $response = new Response();
+it('implements Responsable for error response', function () {
+    $response = new Response();
 
-        $errorResponse = $response->error('Bad Request', 'detail', 400);
-        $result = $errorResponse->toResponse(Request::create('/'));
+    $errorResponse = $response->error('Bad Request', 'detail', 400);
+    $result = $errorResponse->toResponse(Request::create('/'));
 
-        $this->assertSame(400, $result->getStatusCode());
-    }
+    expect($result->getStatusCode())->toBe(400);
+});
 
-    #[Test]
-    #[TestDox('error response omits optional fields when not set')]
-    public function it_omits_optional_error_fields(): void
-    {
-        $response = new Response();
+it('omits optional fields when not set in error response', function () {
+    $response = new Response();
 
-        $result = $response->error('Bad Request')->respond();
-        $data = json_decode($result->getContent(), true);
-        $error = $data['errors'][0];
+    $result = $response->error('Bad Request')->respond();
+    $data = json_decode($result->getContent(), true);
+    $error = $data['errors'][0];
 
-        $this->assertArrayNotHasKey('code', $error);
-        $this->assertArrayNotHasKey('detail', $error);
-        $this->assertArrayNotHasKey('source', $error);
-        $this->assertArrayNotHasKey('meta', $error);
-    }
-}
+    expect($error)->not->toHaveKey('code');
+    expect($error)->not->toHaveKey('detail');
+    expect($error)->not->toHaveKey('source');
+    expect($error)->not->toHaveKey('meta');
+});

--- a/tests/Feature/Rules/ValidIncludeTest.php
+++ b/tests/Feature/Rules/ValidIncludeTest.php
@@ -5,58 +5,40 @@ declare(strict_types = 1);
 namespace BlueBeetle\ApiToolkit\Tests\Feature\Rules;
 
 use BlueBeetle\ApiToolkit\Rules\ValidInclude;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
 use Illuminate\Support\Facades\Validator;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
 
-final class ValidIncludeTest extends TestCase
-{
-    #[Test]
-    #[TestDox('it passes for valid includes')]
-    public function it_passes_valid_includes(): void
-    {
-        $validator = Validator::make(
-            ['include' => 'category,supplier'],
-            ['include' => [new ValidInclude(['category', 'supplier', 'brand'])]],
-        );
+it('passes for valid includes', function () {
+    $validator = Validator::make(
+        ['include' => 'category,supplier'],
+        ['include' => [new ValidInclude(['category', 'supplier', 'brand'])]],
+    );
 
-        $this->assertTrue($validator->passes());
-    }
+    expect($validator->passes())->toBeTrue();
+});
 
-    #[Test]
-    #[TestDox('it fails for invalid includes')]
-    public function it_fails_invalid_includes(): void
-    {
-        $validator = Validator::make(
-            ['include' => 'category,secret'],
-            ['include' => [new ValidInclude(['category', 'supplier'])]],
-        );
+it('fails for invalid includes', function () {
+    $validator = Validator::make(
+        ['include' => 'category,secret'],
+        ['include' => [new ValidInclude(['category', 'supplier'])]],
+    );
 
-        $this->assertFalse($validator->passes());
-    }
+    expect($validator->passes())->toBeFalse();
+});
 
-    #[Test]
-    #[TestDox('it accepts array values')]
-    public function it_accepts_array_values(): void
-    {
-        $validator = Validator::make(
-            ['include' => ['category', 'supplier']],
-            ['include' => [new ValidInclude(['category', 'supplier'])]],
-        );
+it('accepts array values', function () {
+    $validator = Validator::make(
+        ['include' => ['category', 'supplier']],
+        ['include' => [new ValidInclude(['category', 'supplier'])]],
+    );
 
-        $this->assertTrue($validator->passes());
-    }
+    expect($validator->passes())->toBeTrue();
+});
 
-    #[Test]
-    #[TestDox('it provides error message with invalid include names')]
-    public function it_provides_error_message(): void
-    {
-        $validator = Validator::make(
-            ['include' => 'invalid'],
-            ['include' => [new ValidInclude(['category'])]],
-        );
+it('provides error message with invalid include names', function () {
+    $validator = Validator::make(
+        ['include' => 'invalid'],
+        ['include' => [new ValidInclude(['category'])]],
+    );
 
-        $this->assertStringContainsString('invalid', $validator->errors()->first('include'));
-    }
-}
+    expect($validator->errors()->first('include'))->toContain('invalid');
+});

--- a/tests/Feature/Rules/ValidPageSizeTest.php
+++ b/tests/Feature/Rules/ValidPageSizeTest.php
@@ -5,62 +5,44 @@ declare(strict_types = 1);
 namespace BlueBeetle\ApiToolkit\Tests\Feature\Rules;
 
 use BlueBeetle\ApiToolkit\Rules\ValidPageSize;
-use BlueBeetle\ApiToolkit\Tests\TestCase;
 use Illuminate\Support\Facades\Validator;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
 
-final class ValidPageSizeTest extends TestCase
-{
-    #[Test]
-    #[TestDox('it passes for valid page sizes')]
-    public function it_passes_valid_sizes(): void
-    {
-        foreach ([10, 20, 40, 80, 100] as $size) {
-            $validator = Validator::make(
-                ['size' => $size],
-                ['size' => [new ValidPageSize()]],
-            );
-
-            $this->assertTrue($validator->passes(), "Expected {$size} to be valid");
-        }
-    }
-
-    #[Test]
-    #[TestDox('it fails for invalid page sizes')]
-    public function it_fails_invalid_sizes(): void
-    {
-        foreach ([0, 5, 15, 50, 200] as $size) {
-            $validator = Validator::make(
-                ['size' => $size],
-                ['size' => [new ValidPageSize()]],
-            );
-
-            $this->assertFalse($validator->passes(), "Expected {$size} to be invalid");
-        }
-    }
-
-    #[Test]
-    #[TestDox('it supports custom valid sizes')]
-    public function it_supports_custom_sizes(): void
-    {
+it('passes for valid page sizes', function () {
+    foreach ([10, 20, 40, 80, 100] as $size) {
         $validator = Validator::make(
-            ['size' => 25],
-            ['size' => [new ValidPageSize([25, 50, 75])]],
-        );
-
-        $this->assertTrue($validator->passes());
-    }
-
-    #[Test]
-    #[TestDox('it provides error message')]
-    public function it_provides_error_message(): void
-    {
-        $validator = Validator::make(
-            ['size' => 15],
+            ['size' => $size],
             ['size' => [new ValidPageSize()]],
         );
 
-        $this->assertStringContainsString('15', $validator->errors()->first('size'));
+        expect($validator->passes())->toBeTrue("Expected {$size} to be valid");
     }
-}
+});
+
+it('fails for invalid page sizes', function () {
+    foreach ([0, 5, 15, 50, 200] as $size) {
+        $validator = Validator::make(
+            ['size' => $size],
+            ['size' => [new ValidPageSize()]],
+        );
+
+        expect($validator->passes())->toBeFalse("Expected {$size} to be invalid");
+    }
+});
+
+it('supports custom valid sizes', function () {
+    $validator = Validator::make(
+        ['size' => 25],
+        ['size' => [new ValidPageSize([25, 50, 75])]],
+    );
+
+    expect($validator->passes())->toBeTrue();
+});
+
+it('provides error message', function () {
+    $validator = Validator::make(
+        ['size' => 15],
+        ['size' => [new ValidPageSize()]],
+    );
+
+    expect($validator->errors()->first('size'))->toContain('15');
+});

--- a/tests/Feature/Testing/TestDataResponseTest.php
+++ b/tests/Feature/Testing/TestDataResponseTest.php
@@ -6,249 +6,166 @@ namespace BlueBeetle\ApiToolkit\Tests\Feature\Testing;
 
 use BlueBeetle\ApiToolkit\Testing\TestDataResponse;
 use PHPUnit\Framework\AssertionFailedError;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
-use PHPUnit\Framework\TestCase;
 
-final class TestDataResponseTest extends TestCase
-{
-    #[Test]
-    #[TestDox('it asserts count')]
-    public function it_asserts_count(): void
-    {
-        $response = new TestDataResponse(['a', 'b', 'c']);
+it('asserts count', function () {
+    $response = new TestDataResponse(['a', 'b', 'c']);
 
-        $response->assertCount(3);
-    }
+    $response->assertCount(3);
+});
 
-    #[Test]
-    #[TestDox('it fails assertCount with wrong count')]
-    public function it_fails_assert_count(): void
-    {
-        $this->expectException(AssertionFailedError::class);
+it('fails assertCount with wrong count', function () {
+    $response = new TestDataResponse(['a', 'b']);
+    $response->assertCount(5);
+})->throws(AssertionFailedError::class);
 
-        $response = new TestDataResponse(['a', 'b']);
-        $response->assertCount(5);
-    }
+it('asserts same value', function () {
+    $response = new TestDataResponse(['name' => 'Widget', 'code' => 'W01']);
 
-    #[Test]
-    #[TestDox('it asserts same value')]
-    public function it_asserts_same(): void
-    {
-        $response = new TestDataResponse(['name' => 'Widget', 'code' => 'W01']);
+    $response->assertSame('name', 'Widget');
+    $response->assertSame('code', 'W01');
+});
 
-        $response->assertSame('name', 'Widget');
-        $response->assertSame('code', 'W01');
-    }
+it('asserts not same value', function () {
+    $response = new TestDataResponse(['name' => 'Widget']);
 
-    #[Test]
-    #[TestDox('it asserts not same value')]
-    public function it_asserts_not_same(): void
-    {
-        $response = new TestDataResponse(['name' => 'Widget']);
+    $response->assertNotSame('name', 'Gadget');
+});
 
-        $response->assertNotSame('name', 'Gadget');
-    }
+it('asserts true', function () {
+    $response = new TestDataResponse(['active' => true]);
 
-    #[Test]
-    #[TestDox('it asserts true')]
-    public function it_asserts_true(): void
-    {
-        $response = new TestDataResponse(['active' => true]);
+    $response->assertTrue('active');
+});
 
-        $response->assertTrue('active');
-    }
+it('asserts false', function () {
+    $response = new TestDataResponse(['archived' => false]);
 
-    #[Test]
-    #[TestDox('it asserts false')]
-    public function it_asserts_false(): void
-    {
-        $response = new TestDataResponse(['archived' => false]);
+    $response->assertFalse('archived');
+});
 
-        $response->assertFalse('archived');
-    }
+it('asserts null', function () {
+    $response = new TestDataResponse(['description' => null]);
 
-    #[Test]
-    #[TestDox('it asserts null')]
-    public function it_asserts_null(): void
-    {
-        $response = new TestDataResponse(['description' => null]);
+    $response->assertNull('description');
+});
 
-        $response->assertNull('description');
-    }
+it('asserts not null', function () {
+    $response = new TestDataResponse(['name' => 'Widget']);
 
-    #[Test]
-    #[TestDox('it asserts not null')]
-    public function it_asserts_not_null(): void
-    {
-        $response = new TestDataResponse(['name' => 'Widget']);
+    $response->assertNotNull('name');
+});
 
-        $response->assertNotNull('name');
-    }
+it('asserts empty', function () {
+    $response = new TestDataResponse([]);
 
-    #[Test]
-    #[TestDox('it asserts empty')]
-    public function it_asserts_empty(): void
-    {
-        $response = new TestDataResponse([]);
+    $response->assertEmpty();
+});
 
-        $response->assertEmpty();
-    }
+it('asserts not empty', function () {
+    $response = new TestDataResponse(['a']);
 
-    #[Test]
-    #[TestDox('it asserts not empty')]
-    public function it_asserts_not_empty(): void
-    {
-        $response = new TestDataResponse(['a']);
+    $response->assertNotEmpty();
+});
 
-        $response->assertNotEmpty();
-    }
+it('scopes to an item by index', function () {
+    $response = new TestDataResponse([
+        ['type' => 'products', 'id' => '1'],
+        ['type' => 'products', 'id' => '2'],
+    ]);
 
-    #[Test]
-    #[TestDox('it scopes to an item by index')]
-    public function it_scopes_to_item(): void
-    {
-        $response = new TestDataResponse([
-            ['type' => 'products', 'id' => '1'],
-            ['type' => 'products', 'id' => '2'],
-        ]);
+    $response->item(0)->assertSame('id', '1');
+    $response->item(1)->assertSame('id', '2');
+});
 
-        $response->item(0)->assertSame('id', '1');
-        $response->item(1)->assertSame('id', '2');
-    }
+it('fails scoping to non-existent item index', function () {
+    $response = new TestDataResponse([['id' => '1']]);
+    $response->item(5);
+})->throws(AssertionFailedError::class);
 
-    #[Test]
-    #[TestDox('it fails scoping to non-existent item index')]
-    public function it_fails_on_invalid_item_index(): void
-    {
-        $this->expectException(AssertionFailedError::class);
+it('scopes to attributes', function () {
+    $response = new TestDataResponse([
+        'attributes' => ['name' => 'Widget', 'code' => 'W01'],
+    ]);
 
-        $response = new TestDataResponse([['id' => '1']]);
-        $response->item(5);
-    }
+    $response->attributes()->assertSame('name', 'Widget');
+});
 
-    #[Test]
-    #[TestDox('it scopes to attributes')]
-    public function it_scopes_to_attributes(): void
-    {
-        $response = new TestDataResponse([
-            'attributes' => ['name' => 'Widget', 'code' => 'W01'],
-        ]);
+it('scopes to relationships', function () {
+    $response = new TestDataResponse([
+        'relationships' => [
+            'category' => ['data' => ['type' => 'categories', 'id' => '1']],
+        ],
+    ]);
 
-        $response->attributes()->assertSame('name', 'Widget');
-    }
+    $response->relationships()->assertHasKey('category');
+});
 
-    #[Test]
-    #[TestDox('it scopes to relationships')]
-    public function it_scopes_to_relationships(): void
-    {
-        $response = new TestDataResponse([
-            'relationships' => [
-                'category' => ['data' => ['type' => 'categories', 'id' => '1']],
-            ],
-        ]);
+it('scopes to meta', function () {
+    $response = new TestDataResponse([
+        'meta' => ['version' => 1],
+    ]);
 
-        $response->relationships()->assertHasKey('category');
-    }
+    $response->meta()->assertSame('version', 1);
+});
 
-    #[Test]
-    #[TestDox('it scopes to meta')]
-    public function it_scopes_to_meta(): void
-    {
-        $response = new TestDataResponse([
-            'meta' => ['version' => 1],
-        ]);
+it('scopes to links', function () {
+    $response = new TestDataResponse([
+        'links' => ['self' => '/products/1'],
+    ]);
 
-        $response->meta()->assertSame('version', 1);
-    }
+    $response->links()->assertSame('self', '/products/1');
+});
 
-    #[Test]
-    #[TestDox('it scopes to links')]
-    public function it_scopes_to_links(): void
-    {
-        $response = new TestDataResponse([
-            'links' => ['self' => '/products/1'],
-        ]);
+it('asserts has key', function () {
+    $response = new TestDataResponse(['name' => 'Widget']);
 
-        $response->links()->assertSame('self', '/products/1');
-    }
+    $response->assertHasKey('name');
+});
 
-    #[Test]
-    #[TestDox('it asserts has key')]
-    public function it_asserts_has_key(): void
-    {
-        $response = new TestDataResponse(['name' => 'Widget']);
+it('fails assertHasKey for missing key', function () {
+    $response = new TestDataResponse(['name' => 'Widget']);
+    $response->assertHasKey('missing');
+})->throws(AssertionFailedError::class);
 
-        $response->assertHasKey('name');
-    }
+it('asserts missing key', function () {
+    $response = new TestDataResponse(['name' => 'Widget']);
 
-    #[Test]
-    #[TestDox('it fails assertHasKey for missing key')]
-    public function it_fails_assert_has_key(): void
-    {
-        $this->expectException(AssertionFailedError::class);
+    $response->assertMissingKey('email');
+});
 
-        $response = new TestDataResponse(['name' => 'Widget']);
-        $response->assertHasKey('missing');
-    }
+it('fails assertMissingKey when key exists', function () {
+    $response = new TestDataResponse(['name' => 'Widget']);
+    $response->assertMissingKey('name');
+})->throws(AssertionFailedError::class);
 
-    #[Test]
-    #[TestDox('it asserts missing key')]
-    public function it_asserts_missing_key(): void
-    {
-        $response = new TestDataResponse(['name' => 'Widget']);
+it('supports dot notation for nested keys', function () {
+    $response = new TestDataResponse([
+        'nested' => ['deep' => ['value' => 'found']],
+    ]);
 
-        $response->assertMissingKey('email');
-    }
+    $response->assertSame('nested.deep.value', 'found');
+    $response->assertHasKey('nested.deep.value');
+    $response->assertMissingKey('nested.deep.missing');
+});
 
-    #[Test]
-    #[TestDox('it fails assertMissingKey when key exists')]
-    public function it_fails_assert_missing_key(): void
-    {
-        $this->expectException(AssertionFailedError::class);
+it('returns self from all assertions for chaining', function () {
+    $response = new TestDataResponse(['name' => 'Widget', 'active' => true]);
 
-        $response = new TestDataResponse(['name' => 'Widget']);
-        $response->assertMissingKey('name');
-    }
+    $result = $response
+        ->assertSame('name', 'Widget')
+        ->assertTrue('active')
+        ->assertNotEmpty()
+        ->assertHasKey('name')
+    ;
 
-    #[Test]
-    #[TestDox('it supports dot notation for nested keys')]
-    public function it_supports_dot_notation(): void
-    {
-        $response = new TestDataResponse([
-            'nested' => ['deep' => ['value' => 'found']],
-        ]);
+    expect($result)->toBeInstanceOf(TestDataResponse::class);
+});
 
-        $response->assertSame('nested.deep.value', 'found');
-        $response->assertHasKey('nested.deep.value');
-        $response->assertMissingKey('nested.deep.missing');
-    }
+it('returns empty data when scoping to missing attributes', function () {
+    $response = new TestDataResponse([]);
 
-    #[Test]
-    #[TestDox('it returns self from all assertions for chaining')]
-    public function it_supports_chaining(): void
-    {
-        $response = new TestDataResponse(['name' => 'Widget', 'active' => true]);
-
-        $result = $response
-            ->assertSame('name', 'Widget')
-            ->assertTrue('active')
-            ->assertNotEmpty()
-            ->assertHasKey('name')
-        ;
-
-        $this->assertInstanceOf(TestDataResponse::class, $result);
-    }
-
-    #[Test]
-    #[TestDox('it returns empty data when scoping to missing attributes')]
-    public function it_handles_missing_scope_keys(): void
-    {
-        $response = new TestDataResponse([]);
-
-        $response->attributes()->assertEmpty();
-        $response->relationships()->assertEmpty();
-        $response->meta()->assertEmpty();
-        $response->links()->assertEmpty();
-    }
-}
+    $response->attributes()->assertEmpty();
+    $response->relationships()->assertEmpty();
+    $response->meta()->assertEmpty();
+    $response->links()->assertEmpty();
+});

--- a/tests/Feature/Testing/TestResponseTest.php
+++ b/tests/Feature/Testing/TestResponseTest.php
@@ -8,234 +8,173 @@ use BlueBeetle\ApiToolkit\Testing\TestDataResponse;
 use BlueBeetle\ApiToolkit\Testing\TestResponse;
 use Illuminate\Http\JsonResponse;
 use PHPUnit\Framework\AssertionFailedError;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestDox;
-use PHPUnit\Framework\TestCase;
 
-final class TestResponseTest extends TestCase
+function makeTestResponse(array $data, int $status = 200): TestResponse
 {
-    #[Test]
-    #[TestDox('it returns errors as TestDataResponse')]
-    public function it_returns_errors(): void
-    {
-        $response = $this->makeResponse([
-            'errors' => [
-                ['status' => '400', 'title' => 'Bad Request', 'detail' => 'Something went wrong'],
-            ],
-        ]);
+    $jsonResponse = new JsonResponse($data, $status);
 
-        $errors = $response->errors();
-
-        $this->assertInstanceOf(TestDataResponse::class, $errors);
-        $errors->item(0)->assertSame('title', 'Bad Request');
-    }
-
-    #[Test]
-    #[TestDox('it returns data as TestDataResponse')]
-    public function it_returns_data(): void
-    {
-        $response = $this->makeResponse([
-            'data' => ['type' => 'products', 'id' => '1', 'attributes' => ['name' => 'Widget']],
-        ]);
-
-        $data = $response->data();
-
-        $this->assertInstanceOf(TestDataResponse::class, $data);
-        $data->assertSame('type', 'products');
-    }
-
-    #[Test]
-    #[TestDox('it returns attributes as shortcut')]
-    public function it_returns_attributes(): void
-    {
-        $response = $this->makeResponse([
-            'data' => ['type' => 'products', 'id' => '1', 'attributes' => ['name' => 'Widget']],
-        ]);
-
-        $response->attributes()->assertSame('name', 'Widget');
-    }
-
-    #[Test]
-    #[TestDox('it returns included as TestDataResponse')]
-    public function it_returns_included(): void
-    {
-        $response = $this->makeResponse([
-            'data' => [],
-            'included' => [
-                ['type' => 'categories', 'id' => '1', 'attributes' => ['name' => 'Electronics']],
-            ],
-        ]);
-
-        $response->included()->assertCount(1);
-        $response->included()->item(0)->assertSame('type', 'categories');
-    }
-
-    #[Test]
-    #[TestDox('it returns empty TestDataResponse when included is missing')]
-    public function it_handles_missing_included(): void
-    {
-        $response = $this->makeResponse(['data' => []]);
-
-        $response->included()->assertEmpty();
-    }
-
-    #[Test]
-    #[TestDox('it returns meta as TestDataResponse')]
-    public function it_returns_meta(): void
-    {
-        $response = $this->makeResponse([
-            'data' => [],
-            'meta' => ['page' => ['currentPage' => 1, 'total' => 50]],
-        ]);
-
-        $response->meta()->assertHasKey('page');
-    }
-
-    #[Test]
-    #[TestDox('it asserts error title')]
-    public function it_asserts_error_title(): void
-    {
-        $response = $this->makeResponse([
-            'errors' => [['status' => '400', 'title' => 'Bad Request']],
-        ]);
-
-        $response->assertErrorTitle('Bad Request');
-    }
-
-    #[Test]
-    #[TestDox('it asserts error detail')]
-    public function it_asserts_error_detail(): void
-    {
-        $response = $this->makeResponse([
-            'errors' => [['status' => '400', 'title' => 'Bad Request', 'detail' => 'Missing field: name']],
-        ]);
-
-        $response->assertErrorDetail('Missing field: name');
-    }
-
-    #[Test]
-    #[TestDox('it asserts error detail contains substring')]
-    public function it_asserts_error_detail_contains(): void
-    {
-        $response = $this->makeResponse([
-            'errors' => [['status' => '400', 'detail' => 'Missing required field: name']],
-        ]);
-
-        $response->assertErrorDetailContains('required field');
-    }
-
-    #[Test]
-    #[TestDox('it fails assertErrorDetailContains when substring not found')]
-    public function it_fails_error_detail_contains(): void
-    {
-        $this->expectException(AssertionFailedError::class);
-
-        $response = $this->makeResponse([
-            'errors' => [['detail' => 'Something else']],
-        ]);
-
-        $response->assertErrorDetailContains('not present');
-    }
-
-    #[Test]
-    #[TestDox('it asserts error code')]
-    public function it_asserts_error_code(): void
-    {
-        $response = $this->makeResponse([
-            'errors' => [['code' => 'validation_error']],
-        ]);
-
-        $response->assertErrorCode('validation_error');
-    }
-
-    #[Test]
-    #[TestDox('it asserts validation error with field and message')]
-    public function it_asserts_validation_error(): void
-    {
-        $response = $this->makeResponse([
-            'errors' => [
-                ['detail' => 'The name field is required.', 'source' => ['pointer' => '/name']],
-                ['detail' => 'The email must be valid.', 'source' => ['pointer' => '/email']],
-            ],
-        ]);
-
-        $response->assertValidationError('name', 'The name field is required.');
-        $response->assertValidationError('email', 'The email must be valid.');
-    }
-
-    #[Test]
-    #[TestDox('it asserts validation error with nested field pointer')]
-    public function it_asserts_nested_validation_error(): void
-    {
-        $response = $this->makeResponse([
-            'errors' => [
-                ['detail' => 'Invalid value.', 'source' => ['pointer' => '/data/attributes/name']],
-            ],
-        ]);
-
-        $response->assertValidationError('data.attributes.name', 'Invalid value.');
-    }
-
-    #[Test]
-    #[TestDox('it fails assertValidationError when field not found')]
-    public function it_fails_validation_error(): void
-    {
-        $this->expectException(AssertionFailedError::class);
-
-        $response = $this->makeResponse([
-            'errors' => [
-                ['detail' => 'Required.', 'source' => ['pointer' => '/name']],
-            ],
-        ]);
-
-        $response->assertValidationError('email', 'Required.');
-    }
-
-    #[Test]
-    #[TestDox('it asserts resource type')]
-    public function it_asserts_resource_type(): void
-    {
-        $response = $this->makeResponse([
-            'data' => ['type' => 'products', 'id' => '1'],
-        ]);
-
-        $response->assertResourceType('products');
-    }
-
-    #[Test]
-    #[TestDox('it asserts resource id')]
-    public function it_asserts_resource_id(): void
-    {
-        $response = $this->makeResponse([
-            'data' => ['type' => 'products', 'id' => 'abc-123'],
-        ]);
-
-        $response->assertResourceId('abc-123');
-    }
-
-    #[Test]
-    #[TestDox('it returns self from assertion methods for chaining')]
-    public function it_supports_chaining(): void
-    {
-        $response = $this->makeResponse([
-            'errors' => [
-                ['status' => '422', 'code' => 'validation_error', 'title' => 'Validation Error', 'detail' => 'Name is required.'],
-            ],
-        ]);
-
-        $result = $response
-            ->assertErrorTitle('Validation Error')
-            ->assertErrorDetail('Name is required.')
-            ->assertErrorCode('validation_error')
-        ;
-
-        $this->assertInstanceOf(TestResponse::class, $result);
-    }
-
-    private function makeResponse(array $data, int $status = 200): TestResponse
-    {
-        $jsonResponse = new JsonResponse($data, $status);
-
-        return TestResponse::fromBaseResponse($jsonResponse);
-    }
+    return TestResponse::fromBaseResponse($jsonResponse);
 }
+
+it('returns errors as TestDataResponse', function () {
+    $response = makeTestResponse([
+        'errors' => [
+            ['status' => '400', 'title' => 'Bad Request', 'detail' => 'Something went wrong'],
+        ],
+    ]);
+
+    $errors = $response->errors();
+
+    expect($errors)->toBeInstanceOf(TestDataResponse::class);
+    $errors->item(0)->assertSame('title', 'Bad Request');
+});
+
+it('returns data as TestDataResponse', function () {
+    $response = makeTestResponse([
+        'data' => ['type' => 'products', 'id' => '1', 'attributes' => ['name' => 'Widget']],
+    ]);
+
+    $data = $response->data();
+
+    expect($data)->toBeInstanceOf(TestDataResponse::class);
+    $data->assertSame('type', 'products');
+});
+
+it('returns attributes as shortcut', function () {
+    $response = makeTestResponse([
+        'data' => ['type' => 'products', 'id' => '1', 'attributes' => ['name' => 'Widget']],
+    ]);
+
+    $response->attributes()->assertSame('name', 'Widget');
+});
+
+it('returns included as TestDataResponse', function () {
+    $response = makeTestResponse([
+        'data' => [],
+        'included' => [
+            ['type' => 'categories', 'id' => '1', 'attributes' => ['name' => 'Electronics']],
+        ],
+    ]);
+
+    $response->included()->assertCount(1);
+    $response->included()->item(0)->assertSame('type', 'categories');
+});
+
+it('returns empty TestDataResponse when included is missing', function () {
+    $response = makeTestResponse(['data' => []]);
+
+    $response->included()->assertEmpty();
+});
+
+it('returns meta as TestDataResponse', function () {
+    $response = makeTestResponse([
+        'data' => [],
+        'meta' => ['page' => ['currentPage' => 1, 'total' => 50]],
+    ]);
+
+    $response->meta()->assertHasKey('page');
+});
+
+it('asserts error title', function () {
+    $response = makeTestResponse([
+        'errors' => [['status' => '400', 'title' => 'Bad Request']],
+    ]);
+
+    $response->assertErrorTitle('Bad Request');
+});
+
+it('asserts error detail', function () {
+    $response = makeTestResponse([
+        'errors' => [['status' => '400', 'title' => 'Bad Request', 'detail' => 'Missing field: name']],
+    ]);
+
+    $response->assertErrorDetail('Missing field: name');
+});
+
+it('asserts error detail contains substring', function () {
+    $response = makeTestResponse([
+        'errors' => [['status' => '400', 'detail' => 'Missing required field: name']],
+    ]);
+
+    $response->assertErrorDetailContains('required field');
+});
+
+it('fails assertErrorDetailContains when substring not found', function () {
+    $response = makeTestResponse([
+        'errors' => [['detail' => 'Something else']],
+    ]);
+
+    $response->assertErrorDetailContains('not present');
+})->throws(AssertionFailedError::class);
+
+it('asserts error code', function () {
+    $response = makeTestResponse([
+        'errors' => [['code' => 'validation_error']],
+    ]);
+
+    $response->assertErrorCode('validation_error');
+});
+
+it('asserts validation error with field and message', function () {
+    $response = makeTestResponse([
+        'errors' => [
+            ['detail' => 'The name field is required.', 'source' => ['pointer' => '/name']],
+            ['detail' => 'The email must be valid.', 'source' => ['pointer' => '/email']],
+        ],
+    ]);
+
+    $response->assertValidationError('name', 'The name field is required.');
+    $response->assertValidationError('email', 'The email must be valid.');
+});
+
+it('asserts validation error with nested field pointer', function () {
+    $response = makeTestResponse([
+        'errors' => [
+            ['detail' => 'Invalid value.', 'source' => ['pointer' => '/data/attributes/name']],
+        ],
+    ]);
+
+    $response->assertValidationError('data.attributes.name', 'Invalid value.');
+});
+
+it('fails assertValidationError when field not found', function () {
+    $response = makeTestResponse([
+        'errors' => [
+            ['detail' => 'Required.', 'source' => ['pointer' => '/name']],
+        ],
+    ]);
+
+    $response->assertValidationError('email', 'Required.');
+})->throws(AssertionFailedError::class);
+
+it('asserts resource type', function () {
+    $response = makeTestResponse([
+        'data' => ['type' => 'products', 'id' => '1'],
+    ]);
+
+    $response->assertResourceType('products');
+});
+
+it('asserts resource id', function () {
+    $response = makeTestResponse([
+        'data' => ['type' => 'products', 'id' => 'abc-123'],
+    ]);
+
+    $response->assertResourceId('abc-123');
+});
+
+it('returns self from assertion methods for chaining', function () {
+    $response = makeTestResponse([
+        'errors' => [
+            ['status' => '422', 'code' => 'validation_error', 'title' => 'Validation Error', 'detail' => 'Name is required.'],
+        ],
+    ]);
+
+    $result = $response
+        ->assertErrorTitle('Validation Error')
+        ->assertErrorDetail('Name is required.')
+        ->assertErrorCode('validation_error')
+    ;
+
+    expect($result)->toBeInstanceOf(TestResponse::class);
+});

--- a/tests/Fixtures/Controllers/ProductCreateController.php
+++ b/tests/Fixtures/Controllers/ProductCreateController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace BlueBeetle\ApiToolkit\Tests\Fixtures\Controllers;
+
+use BlueBeetle\ApiToolkit\Http\Response;
+use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\Product;
+use BlueBeetle\ApiToolkit\Tests\Fixtures\Resources\ProductResource;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class ProductCreateController
+{
+    public function __invoke(Request $request, Response $response): JsonResponse
+    {
+        $product = Product::create($request->all());
+
+        return $response->success($product, ProductResource::class)->respond(201);
+    }
+}

--- a/tests/Fixtures/Controllers/ProductDeleteController.php
+++ b/tests/Fixtures/Controllers/ProductDeleteController.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace BlueBeetle\ApiToolkit\Tests\Fixtures\Controllers;
+
+use BlueBeetle\ApiToolkit\Http\Response;
+use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\Product;
+use Illuminate\Http\JsonResponse;
+
+final class ProductDeleteController
+{
+    public function __invoke(Product $product, Response $response): JsonResponse
+    {
+        $product->delete();
+
+        return $response->success()->respond(204);
+    }
+}

--- a/tests/Fixtures/Controllers/ProductListController.php
+++ b/tests/Fixtures/Controllers/ProductListController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace BlueBeetle\ApiToolkit\Tests\Fixtures\Controllers;
+
+use BlueBeetle\ApiToolkit\Http\Response;
+use BlueBeetle\ApiToolkit\QueryBuilder;
+use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\Product;
+use BlueBeetle\ApiToolkit\Tests\Fixtures\Resources\ProductResource;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class ProductListController
+{
+    public function __invoke(Request $request, Response $response): JsonResponse
+    {
+        $products = QueryBuilder::for(Product::class, $request)
+            ->fromResource(ProductResource::class)
+            ->paginate()
+        ;
+
+        return $response->success($products, ProductResource::class)->respond();
+    }
+}

--- a/tests/Fixtures/Controllers/ProductViewController.php
+++ b/tests/Fixtures/Controllers/ProductViewController.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace BlueBeetle\ApiToolkit\Tests\Fixtures\Controllers;
+
+use BlueBeetle\ApiToolkit\Http\Response;
+use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\Product;
+use BlueBeetle\ApiToolkit\Tests\Fixtures\Resources\ProductResource;
+use Illuminate\Http\JsonResponse;
+
+final class ProductViewController
+{
+    public function __invoke(Product $product, Response $response): JsonResponse
+    {
+        return $response->success($product, ProductResource::class)->respond();
+    }
+}

--- a/tests/Fixtures/Resources/AppInfoTestResource.php
+++ b/tests/Fixtures/Resources/AppInfoTestResource.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace BlueBeetle\ApiToolkit\Tests\Fixtures\Resources;
+
+use BlueBeetle\ApiToolkit\Resources\Resource;
+
+class AppInfoTestResource extends Resource
+{
+    protected string $type = 'app-info';
+
+    public function attributes($info): array
+    {
+        return [
+            'name' => $info->name,
+            'version' => $info->version,
+        ];
+    }
+
+    public function self($info): string | null
+    {
+        return '/api/v1/info';
+    }
+
+    public function links($info): array
+    {
+        return [
+            'docs' => 'https://docs.example.com',
+        ];
+    }
+
+    public function meta($info): array
+    {
+        return [
+            'uptime' => '99.9%',
+        ];
+    }
+}

--- a/tests/Fixtures/Resources/StatTestResource.php
+++ b/tests/Fixtures/Resources/StatTestResource.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace BlueBeetle\ApiToolkit\Tests\Fixtures\Resources;
+
+use BlueBeetle\ApiToolkit\Resources\Resource;
+
+class StatTestResource extends Resource
+{
+    protected string $type = 'stats';
+
+    public function attributes($stat): array
+    {
+        return [
+            'label' => $stat->label,
+            'value' => $stat->value,
+        ];
+    }
+}

--- a/tests/Fixtures/Resources/TimestampTestResource.php
+++ b/tests/Fixtures/Resources/TimestampTestResource.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace BlueBeetle\ApiToolkit\Tests\Fixtures\Resources;
+
+use BlueBeetle\ApiToolkit\Resources\Resource;
+
+class TimestampTestResource extends Resource
+{
+    protected string $type = 'timestamps';
+
+    public function attributes($date): array
+    {
+        return [
+            'human' => $date->diffForHumans(),
+            'string' => $date->toDateTimeString(),
+            'timestamp' => $date->timestamp,
+        ];
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types = 1);
+
+use BlueBeetle\ApiToolkit\Tests\TestCase;
+
+uses(TestCase::class)->in('Acceptance', 'Feature');


### PR DESCRIPTION
Replace PHPUnit class-based tests with Pest functional syntax across all 30 test files. Switch from phpunit/phpunit to pestphp/pest ^4.6.3 and update composer scripts. Extract remaining inline stubs from NonModelEndpointTest and GenerateOpenApiTest into dedicated fixture files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bluebeetlept/codesmith/api-toolkit/pr/17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->