### PR TITLE
Use primary key as default ID resolver instead of public_id

### DIFF
--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -19,20 +19,28 @@ use Illuminate\Http\Request;
 
 final class QueryBuilder
 {
-    /** @var class-string<resource>|null */
+    /**
+     * @var class-string<resource>|null
+     */
     private string | null $resourceClass = null;
 
     private Resource | null $resourceInstance = null;
 
-    /** @var array<string, class-string<Filter>|Filter>|null */
+    /**
+     * @var array<string, class-string<Filter>|Filter>|null
+     */
     private array | null $filters = null;
 
-    /** @var list<string>|null */
+    /**
+     * @var list<string>|null
+     */
     private array | null $sorts = null;
 
     private string | null $defaultSort = null;
 
-    /** @var list<string>|null */
+    /**
+     * @var list<string>|null
+     */
     private array | null $includes = null;
 
     private bool $defaultSortOverridden = false;

--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -23,10 +23,14 @@ use Illuminate\Support\Str;
  */
 class Resource
 {
-    /** @var (Closure(mixed, Request|null): string)|null */
+    /**
+     * @var (Closure(mixed, Request|null): string)|null
+     */
     private static Closure | null $idResolver = null;
 
-    /** @var (Closure(mixed, Request|null): string)|null */
+    /**
+     * @var (Closure(mixed, Request|null): string)|null
+     */
     private static Closure | null $typeResolver = null;
 
     /**
@@ -215,15 +219,11 @@ class Resource
         }
 
         if ($model instanceof Model) {
-            return (string) ($model->public_id ?? $model->getKey());
+            return (string) $model->getKey();
         }
 
         if (is_object($model) && property_exists($model, 'id')) {
             return (string) $model->id;
-        }
-
-        if (is_object($model) && property_exists($model, 'public_id')) {
-            return (string) $model->public_id;
         }
 
         return '';

--- a/tests/Acceptance/JsonApi/ListEndpointTest.php
+++ b/tests/Acceptance/JsonApi/ListEndpointTest.php
@@ -38,7 +38,7 @@ it('returns a valid JSON:API collection response', function () {
     ]);
 
     $response->assertJsonPath('data.0.type', 'products');
-    $response->assertJsonPath('data.0.id', 'p1');
+    $response->assertJsonPath('data.0.id', '1');
     $response->assertJsonPath('data.0.attributes.name', 'Widget');
     $response->assertJsonPath('data.0.attributes.code', 'W01');
 });
@@ -104,7 +104,7 @@ it('includes relationships when requested', function () {
     $response->assertStatus(200);
 
     $response->assertJsonPath('data.0.relationships.category.data.type', 'categories');
-    $response->assertJsonPath('data.0.relationships.category.data.id', 'c1');
+    $response->assertJsonPath('data.0.relationships.category.data.id', (string) $category->id);
 
     $response->assertJsonStructure([
         'included' => [
@@ -113,7 +113,7 @@ it('includes relationships when requested', function () {
     ]);
 
     $response->assertJsonPath('included.0.type', 'categories');
-    $response->assertJsonPath('included.0.id', 'c1');
+    $response->assertJsonPath('included.0.id', (string) $category->id);
     $response->assertJsonPath('included.0.attributes.name', 'Electronics');
 });
 

--- a/tests/Acceptance/JsonApi/SingleEndpointTest.php
+++ b/tests/Acceptance/JsonApi/SingleEndpointTest.php
@@ -42,7 +42,7 @@ it('returns a valid JSON:API single resource response', function () {
     ]);
 
     $response->assertJsonPath('data.type', 'products');
-    $response->assertJsonPath('data.id', 'p1');
+    $response->assertJsonPath('data.id', (string) Product::where('public_id', 'p1')->first()->id);
     $response->assertJsonPath('data.attributes.name', 'Widget');
     $response->assertJsonPath('data.attributes.code', 'W01');
     $response->assertJsonPath('data.attributes.description', 'A fine widget');
@@ -59,7 +59,7 @@ it('includes loaded relationships in response', function () {
 
     $response->assertStatus(200);
     $response->assertJsonPath('data.relationships.category.data.type', 'categories');
-    $response->assertJsonPath('data.relationships.category.data.id', 'c1');
+    $response->assertJsonPath('data.relationships.category.data.id', (string) $category->id);
 });
 
 it('includes self link', function () {

--- a/tests/Feature/Resources/ResourceTest.php
+++ b/tests/Feature/Resources/ResourceTest.php
@@ -49,7 +49,7 @@ it('returns null when model is null', function () {
     expect($resource->toArray(null))->toBeNull();
 });
 
-it('resolves id from public_id when available', function () {
+it('resolves id from id property on plain objects', function () {
     $resource = new class() extends Resource {
         protected string $type = 'items';
 
@@ -60,11 +60,11 @@ it('resolves id from public_id when available', function () {
     };
 
     $model = new stdClass();
-    $model->public_id = 'pub-456';
+    $model->id = 'obj-456';
 
     $result = $resource->toArray($model);
 
-    expect($result['id'])->toBe('pub-456');
+    expect($result['id'])->toBe('obj-456');
 });
 
 it('uses the static make method for quick transformation', function () {


### PR DESCRIPTION
The default resolveId() now uses getKey() for Eloquent models and the id property for plain objects. The public_id preference was an internal convention that doesn't belong in a public package. Users who need public_id can register a global resolver via resolveIdUsing().

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bluebeetlept/codesmith/api-toolkit/pr/18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->