### PR TITLE
Throw when resource ID cannot be resolved

### DIFF
--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -10,6 +10,7 @@ use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
+use RuntimeException;
 
 /**
  * @template TModel
@@ -226,7 +227,13 @@ class Resource
             return (string) $model->id;
         }
 
-        return '';
+        throw new RuntimeException(
+            sprintf(
+                'Unable to resolve ID for [%s] in resource [%s]. Define an id property or register a global resolver with Resource::resolveIdUsing().',
+                get_debug_type($model),
+                static::class,
+            ),
+        );
     }
 
     /**

--- a/tests/Feature/Resources/ResourceTest.php
+++ b/tests/Feature/Resources/ResourceTest.php
@@ -7,6 +7,7 @@ namespace BlueBeetle\ApiToolkit\Tests\Feature\Resources;
 use BadMethodCallException;
 use BlueBeetle\ApiToolkit\Resources\Resource;
 use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\Product;
+use RuntimeException;
 use stdClass;
 
 it('serializes a model to JSON:API resource object', function () {
@@ -317,6 +318,21 @@ it('resolves type from model instance table name', function () {
 
     expect($result['type'])->toBe('products');
 });
+
+it('throws when id cannot be resolved', function () {
+    $resource = new class() extends Resource {
+        protected string $type = 'items';
+
+        public function attributes($model): array
+        {
+            return [];
+        }
+    };
+
+    $model = new stdClass();
+
+    $resource->toArray($model);
+})->throws(RuntimeException::class, 'Unable to resolve ID');
 
 it('returns empty type when no model and no type set', function () {
     $resource = new class() extends Resource {

--- a/tests/Fixtures/Resources/TimestampTestResource.php
+++ b/tests/Fixtures/Resources/TimestampTestResource.php
@@ -10,6 +10,11 @@ class TimestampTestResource extends Resource
 {
     protected string $type = 'timestamps';
 
+    public function resolveId($model): string
+    {
+        return (string) $model->timestamp;
+    }
+
     public function attributes($date): array
     {
         return [


### PR DESCRIPTION
Instead of silently returning an empty string, resolveId() now throws a RuntimeException with a descriptive message when no ID can be determined. This catches misconfigurations early since JSON:API requires a non-empty id on every resource object.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bluebeetlept/codesmith/api-toolkit/pr/19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->