### PR TITLE
Add sparse fieldsets support, improve ValidPageSize and clean up dead code

### DIFF
--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace BlueBeetle\ApiToolkit\Resources;
 
 use BadMethodCallException;
+use BlueBeetle\ApiToolkit\Parsers\FieldParser;
 use BlueBeetle\ApiToolkit\Parsers\Filters\Filter;
 use Closure;
 use Illuminate\Database\Eloquent\Model;
@@ -108,10 +109,19 @@ class Resource
             );
         }
 
+        $type = $this->resolveType($model);
+        $attributes = $this->attributes($model);
+
+        if ($this->request !== null) {
+            $fieldParser = new FieldParser();
+            $fields = $fieldParser->parse($this->request);
+            $attributes = $fieldParser->filter($attributes, $fields[$type] ?? null);
+        }
+
         return [
-            'type' => $this->resolveType($model),
+            'type' => $type,
             'id' => $this->resolveId($model),
-            'attributes' => $this->attributes($model),
+            'attributes' => $attributes,
             'relationships' => $this->resolveRelationships($model),
             'links' => $this->resolveLinks($model),
             'meta' => $this->resolveMeta($model),

--- a/src/Resources/ResourceCollection.php
+++ b/src/Resources/ResourceCollection.php
@@ -144,13 +144,12 @@ final readonly class ResourceCollection
             ];
         }
 
-        if ($this->data instanceof CursorPaginator) {
-            return [
-                'prev' => $this->data->previousPageUrl(),
-                'next' => $this->data->nextPageUrl(),
-            ];
-        }
+        /** @var CursorPaginator $cursor */
+        $cursor = $this->data;
 
-        return [];
+        return [
+            'prev' => $cursor->previousPageUrl(),
+            'next' => $cursor->nextPageUrl(),
+        ];
     }
 }

--- a/src/Rules/ValidPageSize.php
+++ b/src/Rules/ValidPageSize.php
@@ -9,11 +9,14 @@ use Illuminate\Contracts\Validation\ValidationRule;
 
 final readonly class ValidPageSize implements ValidationRule
 {
+    private array $validSizes;
+
     public function __construct(
-        private array $validSizes = [
-            10, 20, 40, 80, 100,
-        ],
+        array $validSizes = [],
     ) {
+        $this->validSizes = $validSizes !== []
+            ? $validSizes
+            : (array) config('api-toolkit.pagination.valid_sizes', [10, 20, 40, 80, 100]);
     }
 
     public function validate(string $attribute, mixed $value, Closure $fail): void

--- a/tests/Feature/Resources/ResourceTest.php
+++ b/tests/Feature/Resources/ResourceTest.php
@@ -410,3 +410,85 @@ it('returns empty type when no model and no type set', function () {
 
     expect($resource->resolveType())->toBe('');
 });
+
+it('filters attributes with sparse fieldsets from request', function () {
+    $resource = new class() extends Resource {
+        protected string $type = 'products';
+
+        public function attributes($model): array
+        {
+            return [
+                'name' => $model->name,
+                'price' => $model->price,
+                'sku' => $model->sku,
+            ];
+        }
+    };
+
+    $request = \Illuminate\Http\Request::create('/', 'GET', [
+        'fields' => ['products' => 'name,price'],
+    ]);
+
+    $model = new stdClass();
+    $model->id = '1';
+    $model->name = 'Widget';
+    $model->price = 29.99;
+    $model->sku = 'WGT-001';
+
+    $result = $resource->withRequest($request)->toArray($model);
+
+    expect($result['attributes'])->toBe(['name' => 'Widget', 'price' => 29.99]);
+    expect($result['attributes'])->not->toHaveKey('sku');
+});
+
+it('returns all attributes when no sparse fieldset is requested', function () {
+    $resource = new class() extends Resource {
+        protected string $type = 'products';
+
+        public function attributes($model): array
+        {
+            return [
+                'name' => $model->name,
+                'price' => $model->price,
+            ];
+        }
+    };
+
+    $request = \Illuminate\Http\Request::create('/');
+
+    $model = new stdClass();
+    $model->id = '1';
+    $model->name = 'Widget';
+    $model->price = 29.99;
+
+    $result = $resource->withRequest($request)->toArray($model);
+
+    expect($result['attributes'])->toBe(['name' => 'Widget', 'price' => 29.99]);
+});
+
+it('ignores sparse fieldsets for non-matching type', function () {
+    $resource = new class() extends Resource {
+        protected string $type = 'products';
+
+        public function attributes($model): array
+        {
+            return [
+                'name' => $model->name,
+                'price' => $model->price,
+            ];
+        }
+    };
+
+    $request = \Illuminate\Http\Request::create('/', 'GET', [
+        'fields' => ['categories' => 'name'],
+    ]);
+
+    $model = new stdClass();
+    $model->id = '1';
+    $model->name = 'Widget';
+    $model->price = 29.99;
+
+    $result = $resource->withRequest($request)->toArray($model);
+
+    expect($result['attributes'])->toBe(['name' => 'Widget', 'price' => 29.99]);
+});

--- a/tests/Feature/Rules/ValidPageSizeTest.php
+++ b/tests/Feature/Rules/ValidPageSizeTest.php
@@ -46,3 +46,32 @@ it('provides error message', function () {
 
     expect($validator->errors()->first('size'))->toContain('15');
 });
+
+it('reads valid sizes from config when no sizes provided', function () {
+    $this->app['config']->set('api-toolkit.pagination.valid_sizes', [5, 15, 30]);
+
+    $validator = Validator::make(
+        ['size' => 15],
+        ['size' => [new ValidPageSize()]],
+    );
+
+    expect($validator->passes())->toBeTrue();
+
+    $validator = Validator::make(
+        ['size' => 20],
+        ['size' => [new ValidPageSize()]],
+    );
+
+    expect($validator->passes())->toBeFalse();
+});
+
+it('prefers explicit sizes over config', function () {
+    $this->app['config']->set('api-toolkit.pagination.valid_sizes', [5, 15, 30]);
+
+    $validator = Validator::make(
+        ['size' => 25],
+        ['size' => [new ValidPageSize([25, 50])]],
+    );
+
+    expect($validator->passes())->toBeTrue();
+});


### PR DESCRIPTION
- Apply sparse fieldsets automatically in Resource::toArray() when a request with fields parameter is present (?fields[type]=field1,field2)
- ValidPageSize now reads default sizes from config instead of hardcoding
- Remove unreachable return statement in ResourceCollection::resolvePaginationLinks()

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bluebeetlept/codesmith/api-toolkit/pr/21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->