### PR TITLE
Cache sparse fieldsets parsing and add noContent response

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -4,8 +4,8 @@ declare(strict_types = 1);
 
 namespace BlueBeetle\ApiToolkit\Http;
 
-use BlueBeetle\ApiToolkit\Resources\Resource;
 use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
 
 final readonly class Response
 {
@@ -29,6 +29,15 @@ final readonly class Response
         }
 
         return $response;
+    }
+
+    public function noContent(): SymfonyResponse
+    {
+        return new SymfonyResponse(
+            content: '',
+            status: 204,
+            headers: ['Content-Type' => 'application/vnd.api+json'],
+        );
     }
 
     public function error(string $title, string | null $detail = null, int $status = 400): ErrorResponse

--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -54,6 +54,13 @@ class Resource
     protected Request | null $request = null;
 
     /**
+     * Cached parsed sparse fieldsets for the current request.
+     *
+     * @var array<string, list<string>>|null
+     */
+    private array | null $parsedFields = null;
+
+    /**
      * Register a global callback to resolve the resource ID.
      *
      * @param Closure(mixed, Request|null): string $callback
@@ -90,6 +97,7 @@ class Resource
     public function withRequest(Request | null $request): static
     {
         $this->request = $request;
+        $this->parsedFields = null;
 
         return $this;
     }
@@ -113,9 +121,7 @@ class Resource
         $attributes = $this->attributes($model);
 
         if ($this->request !== null) {
-            $fieldParser = new FieldParser();
-            $fields = $fieldParser->parse($this->request);
-            $attributes = $fieldParser->filter($attributes, $fields[$type] ?? null);
+            $attributes = $this->applySparseFieldsets($type, $attributes);
         }
 
         return [
@@ -282,6 +288,20 @@ class Resource
         }
 
         return [];
+    }
+
+    /**
+     * @param array<string, mixed> $attributes
+     *
+     * @return array<string, mixed>
+     */
+    private function applySparseFieldsets(string $type, array $attributes): array
+    {
+        if ($this->parsedFields === null) {
+            $this->parsedFields = (new FieldParser())->parse($this->request);
+        }
+
+        return (new FieldParser())->filter($attributes, $this->parsedFields[$type] ?? null);
     }
 
     /**

--- a/tests/Feature/Resources/ResourceTest.php
+++ b/tests/Feature/Resources/ResourceTest.php
@@ -466,6 +466,45 @@ it('returns all attributes when no sparse fieldset is requested', function () {
     expect($result['attributes'])->toBe(['name' => 'Widget', 'price' => 29.99]);
 });
 
+it('caches sparse fieldsets across multiple toArray calls', function () {
+    $resource = new class() extends Resource {
+        protected string $type = 'products';
+
+        public function attributes($model): array
+        {
+            return [
+                'name' => $model->name,
+                'price' => $model->price,
+                'sku' => $model->sku,
+            ];
+        }
+    };
+
+    $request = \Illuminate\Http\Request::create('/', 'GET', [
+        'fields' => ['products' => 'name'],
+    ]);
+
+    $resource->withRequest($request);
+
+    $model1 = new stdClass();
+    $model1->id = '1';
+    $model1->name = 'Widget';
+    $model1->price = 10;
+    $model1->sku = 'W01';
+
+    $model2 = new stdClass();
+    $model2->id = '2';
+    $model2->name = 'Gadget';
+    $model2->price = 20;
+    $model2->sku = 'G01';
+
+    $result1 = $resource->toArray($model1);
+    $result2 = $resource->toArray($model2);
+
+    expect($result1['attributes'])->toBe(['name' => 'Widget']);
+    expect($result2['attributes'])->toBe(['name' => 'Gadget']);
+});
+
 it('ignores sparse fieldsets for non-matching type', function () {
     $resource = new class() extends Resource {
         protected string $type = 'products';

--- a/tests/Feature/Response/ResponseTest.php
+++ b/tests/Feature/Response/ResponseTest.php
@@ -220,3 +220,13 @@ it('omits optional fields when not set in error response', function () {
     expect($error)->not->toHaveKey('source');
     expect($error)->not->toHaveKey('meta');
 });
+
+it('creates a 204 no content response with empty body', function () {
+    $response = new Response();
+
+    $result = $response->noContent();
+
+    expect($result->getStatusCode())->toBe(204);
+    expect($result->getContent())->toBe('');
+    expect($result->headers->get('Content-Type'))->toBe('application/vnd.api+json');
+});


### PR DESCRIPTION
- Cache parsed sparse fieldsets on the Resource instance to avoid re-parsing the request on every toArray() call
- Add Response::noContent() for proper 204 responses with empty body

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bluebeetlept/codesmith/api-toolkit/pr/22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->