### PR TITLE
Add SearchFilter for multi-column LIKE search

### DIFF
--- a/src/Parsers/Filters/SearchFilter.php
+++ b/src/Parsers/Filters/SearchFilter.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace BlueBeetle\ApiToolkit\Parsers\Filters;
+
+use Illuminate\Database\Eloquent\Builder;
+
+final readonly class SearchFilter implements Filter
+{
+    /**
+     * @param list<string> $columns
+     */
+    public function __construct(
+        private array $columns,
+    ) {
+    }
+
+    public function apply(Builder $query, string $field, mixed $value): void
+    {
+        if ($this->columns === [] || ! is_string($value) || $value === '') {
+            return;
+        }
+
+        $query->where(function (Builder $query) use ($value): void {
+            foreach ($this->columns as $column) {
+                $query->orWhere($column, 'LIKE', '%'.$value.'%');
+            }
+        });
+    }
+}

--- a/tests/Feature/Parsers/SearchFilterTest.php
+++ b/tests/Feature/Parsers/SearchFilterTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace BlueBeetle\ApiToolkit\Tests\Feature\Parsers;
+
+use BlueBeetle\ApiToolkit\Parsers\Filters\SearchFilter;
+use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\Product;
+
+it('searches across multiple columns with OR', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01', 'description' => 'A fine product']);
+    Product::create(['public_id' => 'p2', 'name' => 'Gadget', 'code' => 'G01', 'description' => 'A widget alternative']);
+    Product::create(['public_id' => 'p3', 'name' => 'Doohickey', 'code' => 'D01', 'description' => 'Something else']);
+
+    $filter = new SearchFilter(['name', 'description']);
+    $query = Product::query();
+    $filter->apply($query, 'search', 'widget');
+
+    expect($query->get())->toHaveCount(2);
+});
+
+it('searches a single column', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01']);
+    Product::create(['public_id' => 'p2', 'name' => 'Gadget', 'code' => 'G01']);
+
+    $filter = new SearchFilter(['name']);
+    $query = Product::query();
+    $filter->apply($query, 'search', 'Widget');
+
+    expect($query->get())->toHaveCount(1);
+    expect($query->first()->name)->toBe('Widget');
+});
+
+it('is case insensitive', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01']);
+
+    $filter = new SearchFilter(['name']);
+    $query = Product::query();
+    $filter->apply($query, 'search', 'WIDGET');
+
+    expect($query->get())->toHaveCount(1);
+});
+
+it('does nothing with empty value', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01']);
+
+    $filter = new SearchFilter(['name']);
+    $query = Product::query();
+    $filter->apply($query, 'search', '');
+
+    expect($query->get())->toHaveCount(1);
+});
+
+it('does nothing with non-string value', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01']);
+
+    $filter = new SearchFilter(['name']);
+    $query = Product::query();
+    $filter->apply($query, 'search', ['not', 'a', 'string']);
+
+    expect($query->get())->toHaveCount(1);
+});
+
+it('does nothing with empty columns', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01']);
+
+    $filter = new SearchFilter([]);
+    $query = Product::query();
+    $filter->apply($query, 'search', 'widget');
+
+    expect($query->get())->toHaveCount(1);
+});
+
+it('wraps conditions in a group to preserve other wheres', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01', 'status' => 'active']);
+    Product::create(['public_id' => 'p2', 'name' => 'Widget Pro', 'code' => 'W02', 'status' => 'inactive']);
+    Product::create(['public_id' => 'p3', 'name' => 'Gadget', 'code' => 'G01', 'status' => 'active']);
+
+    $filter = new SearchFilter(['name', 'code']);
+    $query = Product::where('status', 'active');
+    $filter->apply($query, 'search', 'widget');
+
+    $results = $query->get();
+
+    expect($results)->toHaveCount(1);
+    expect($results->first()->public_id)->toBe('p1');
+});
+
+it('works through the query builder', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01']);
+    Product::create(['public_id' => 'p2', 'name' => 'Gadget', 'code' => 'G01']);
+    Product::create(['public_id' => 'p3', 'name' => 'Thingamajig', 'code' => 'WIDG']);
+
+    $request = \Illuminate\Http\Request::create('/', 'GET', [
+        'filter' => ['search' => 'widg'],
+    ]);
+
+    $result = \BlueBeetle\ApiToolkit\QueryBuilder::for(Product::class, $request)
+        ->allowedFilters(['search' => new SearchFilter(['name', 'code'])])
+        ->apply()
+        ->getQuery()
+        ->get()
+    ;
+
+    expect($result)->toHaveCount(2);
+});


### PR DESCRIPTION
Searches across multiple columns using OR conditions, wrapped in a group to preserve other query constraints. Handles empty values, non-string input, and empty column lists gracefully.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bluebeetlept/codesmith/api-toolkit/pr/25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->