### PR TITLE
Add ScoutSearchFilter for Laravel Scout integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     },
     "require-dev": {
         "eufaturo/coding-standards": "dev-main",
+        "laravel/scout": "^11.1",
         "mockery/mockery": "^1.6",
         "orchestra/testbench": "^11.0",
         "pestphp/pest": "^4.6.3"

--- a/docs/1.index.md
+++ b/docs/1.index.md
@@ -11,7 +11,8 @@ API Toolkit is a Laravel package that gives you everything you need to build [JS
 
 - **JSON:API Resources** - Serialize Eloquent models into spec-compliant responses with relationships, links, and metadata
 - **Query Builder** - Fluent API for filtering, sorting, including relationships, and paginating
-- **Built-in Filters** - Exact, partial, date, and scope-based filters out of the box, with support for custom filters
+- **Built-in Filters** - Exact, partial, date, scope, and search filters out of the box, with support for custom filters
+- **Scout Integration** - Full-text search via Laravel Scout (Typesense, Meilisearch, Algolia)
 - **Sparse Fieldsets** - Let clients request only the attributes they need
 - **Pagination** - Offset and cursor-based pagination with configurable page sizes
 - **Error Handling** - Automatic exception rendering in JSON:API format, including validation errors with field pointers

--- a/docs/2.filtering-and-sorting/1.filters.md
+++ b/docs/2.filtering-and-sorting/1.filters.md
@@ -106,6 +106,30 @@ To use a scope name that differs from the filter key, pass it to the constructor
 
 This calls `$query->whereActive($value)` instead of `$query->active($value)`.
 
+### SearchFilter
+
+Searches across multiple columns using `LIKE` with OR conditions. Useful for simple search bars that need to match against several fields at once.
+
+```php
+use BlueBeetle\ApiToolkit\Parsers\Filters\SearchFilter;
+
+public function allowedFilters(): array
+{
+    return [
+        'search' => new SearchFilter(['name', 'description', 'code']),
+    ];
+}
+```
+
+```
+GET /api/products?filter[search]=widget
+→ WHERE (name LIKE '%widget%' OR description LIKE '%widget%' OR code LIKE '%widget%')
+```
+
+The OR conditions are wrapped in a group, so they don't interfere with other filters applied to the same query.
+
+For full-text search powered by Typesense, Meilisearch, or Algolia, see the [Scout integration](/docs/api-toolkit/latest/filtering-and-sorting/scout) page.
+
 ## Custom Filters
 
 Implement the `Filter` interface to create your own:

--- a/docs/2.filtering-and-sorting/6.scout.md
+++ b/docs/2.filtering-and-sorting/6.scout.md
@@ -1,0 +1,120 @@
+---
+title: Scout Integration
+description: Full-text search with Laravel Scout.
+---
+
+# Scout Integration
+
+The toolkit integrates with [Laravel Scout](https://laravel.com/docs/scout) for full-text search. This works with any Scout driver, including Typesense, Meilisearch, Algolia, and the built-in database driver.
+
+## Setup
+
+Install Laravel Scout in your application:
+
+```bash
+composer require laravel/scout
+```
+
+Add the `Searchable` trait to your model:
+
+```php
+use Illuminate\Database\Eloquent\Model;
+use Laravel\Scout\Searchable;
+
+class Product extends Model
+{
+    use Searchable;
+
+    public function toSearchableArray(): array
+    {
+        return [
+            'name'        => $this->name,
+            'description' => $this->description,
+            'code'        => $this->code,
+        ];
+    }
+}
+```
+
+## Using ScoutSearchFilter
+
+Add the `ScoutSearchFilter` to your resource's allowed filters:
+
+```php
+use BlueBeetle\ApiToolkit\Parsers\Filters\ExactFilter;
+use BlueBeetle\ApiToolkit\Parsers\Filters\ScoutSearchFilter;
+use BlueBeetle\ApiToolkit\Resources\Resource;
+
+class ProductResource extends Resource
+{
+    public function allowedFilters(): array
+    {
+        return [
+            'search' => new ScoutSearchFilter(),
+            'status' => new ExactFilter(),
+        ];
+    }
+}
+```
+
+Clients can then search via the `filter[search]` query parameter:
+
+```
+GET /api/products?filter[search]=widget
+GET /api/products?filter[search]=widget&filter[status]=active
+```
+
+## How It Works
+
+1. The filter calls `Model::search($value)` using Scout
+2. Scout queries the configured search engine (Typesense, Meilisearch, etc.)
+3. The matching record IDs are returned
+4. The Eloquent query is constrained with `whereIn(id, [...])`
+
+Because the result is fed back into the Eloquent query, all other toolkit features work on top of the search results: additional filters, sorting, pagination, and includes are all applied as usual.
+
+## Combining with Other Filters
+
+Scout search works alongside all other filters. The search narrows the result set, and additional filters are applied on top:
+
+```php
+use BlueBeetle\ApiToolkit\Parsers\Filters\ExactFilter;
+use BlueBeetle\ApiToolkit\Parsers\Filters\ScoutSearchFilter;
+use BlueBeetle\ApiToolkit\Resources\Resource;
+
+class ProductResource extends Resource
+{
+    public function allowedFilters(): array
+    {
+        return [
+            'search'   => new ScoutSearchFilter(),
+            'status'   => new ExactFilter(),
+            'category' => new ExactFilter(),
+        ];
+    }
+
+    public function allowedSorts(): array
+    {
+        return ['name', 'price', 'created_at'];
+    }
+}
+```
+
+```
+GET /api/products?filter[search]=widget&filter[status]=active&sort=-created_at&page[size]=10
+```
+
+This searches for "widget" via Scout, then filters to active products, sorts by newest first, and paginates.
+
+## When the Model is Not Searchable
+
+If the `ScoutSearchFilter` is applied to a model that doesn't use the `Searchable` trait, the filter is silently skipped. This means you can safely add it to a base resource without worrying about models that don't support search.
+
+## SearchFilter vs ScoutSearchFilter
+
+| Feature | SearchFilter | ScoutSearchFilter |
+|---|---|---|
+| Search engine | Database (LIKE) | Any Scout driver |
+| Columns to search | Defined in constructor | Defined by `toSearchableArray()` |
+| External dependency | None | `laravel/scout` |
+| Best for | Simple search across a few columns | Full-text search with relevance ranking |

--- a/src/Parsers/Filters/ScoutSearchFilter.php
+++ b/src/Parsers/Filters/ScoutSearchFilter.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace BlueBeetle\ApiToolkit\Parsers\Filters;
+
+use Illuminate\Database\Eloquent\Builder;
+
+final readonly class ScoutSearchFilter implements Filter
+{
+    public function apply(Builder $query, string $field, mixed $value): void
+    {
+        if (! is_string($value) || $value === '') {
+            return;
+        }
+
+        $model = $query->getModel();
+
+        if (! method_exists($model, 'search')) {
+            return;
+        }
+
+        $ids = $model::search($value)->keys()->all();
+
+        if ($ids === []) {
+            $query->whereRaw('1 = 0');
+
+            return;
+        }
+
+        $query->whereIn($model->getQualifiedKeyName(), $ids);
+    }
+}

--- a/tests/Feature/Parsers/ScoutSearchFilterTest.php
+++ b/tests/Feature/Parsers/ScoutSearchFilterTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace BlueBeetle\ApiToolkit\Tests\Feature\Parsers;
+
+use BlueBeetle\ApiToolkit\Parsers\Filters\ScoutSearchFilter;
+use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\Product;
+use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\SearchableProduct;
+
+beforeEach(function () {
+    $this->app->register(\Laravel\Scout\ScoutServiceProvider::class);
+    $this->app['config']->set('scout.driver', 'collection');
+});
+
+it('constrains query using scout search results', function () {
+    $p1 = SearchableProduct::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01']);
+    $p2 = SearchableProduct::create(['public_id' => 'p2', 'name' => 'Gadget', 'code' => 'G01']);
+    $p3 = SearchableProduct::create(['public_id' => 'p3', 'name' => 'Widget Pro', 'code' => 'W02']);
+
+    $filter = new ScoutSearchFilter();
+    $query = SearchableProduct::query();
+    $filter->apply($query, 'search', 'Widget');
+
+    $results = $query->get();
+
+    expect($results)->toHaveCount(2);
+    expect($results->pluck('public_id')->all())->toContain('p1')->toContain('p3');
+});
+
+it('returns no results when scout finds nothing', function () {
+    SearchableProduct::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01']);
+
+    $filter = new ScoutSearchFilter();
+    $query = SearchableProduct::query();
+    $filter->apply($query, 'search', 'zzzznonexistent');
+
+    expect($query->get())->toHaveCount(0);
+});
+
+it('preserves other query constraints', function () {
+    SearchableProduct::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01', 'status' => 'active']);
+    SearchableProduct::create(['public_id' => 'p2', 'name' => 'Widget Pro', 'code' => 'W02', 'status' => 'inactive']);
+
+    $filter = new ScoutSearchFilter();
+    $query = SearchableProduct::where('status', 'active');
+    $filter->apply($query, 'search', 'Widget');
+
+    $results = $query->get();
+
+    expect($results)->toHaveCount(1);
+    expect($results->first()->public_id)->toBe('p1');
+});
+
+it('does nothing with empty value', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01']);
+
+    $filter = new ScoutSearchFilter();
+    $query = Product::query();
+    $filter->apply($query, 'search', '');
+
+    expect($query->get())->toHaveCount(1);
+});
+
+it('does nothing with non-string value', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01']);
+
+    $filter = new ScoutSearchFilter();
+    $query = Product::query();
+    $filter->apply($query, 'search', ['array']);
+
+    expect($query->get())->toHaveCount(1);
+});
+
+it('does nothing when model does not have search method', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01']);
+
+    $filter = new ScoutSearchFilter();
+    $query = Product::query();
+    $filter->apply($query, 'search', 'widget');
+
+    expect($query->get())->toHaveCount(1);
+});
+
+it('works through the query builder', function () {
+    SearchableProduct::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01']);
+    SearchableProduct::create(['public_id' => 'p2', 'name' => 'Gadget', 'code' => 'G01']);
+
+    $request = \Illuminate\Http\Request::create('/', 'GET', [
+        'filter' => ['search' => 'Widget'],
+    ]);
+
+    $result = \BlueBeetle\ApiToolkit\QueryBuilder::for(SearchableProduct::class, $request)
+        ->allowedFilters(['search' => new ScoutSearchFilter()])
+        ->apply()
+        ->getQuery()
+        ->get()
+    ;
+
+    expect($result)->toHaveCount(1);
+    expect($result->first()->name)->toBe('Widget');
+});

--- a/tests/Fixtures/Models/SearchableProduct.php
+++ b/tests/Fixtures/Models/SearchableProduct.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace BlueBeetle\ApiToolkit\Tests\Fixtures\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Laravel\Scout\Searchable;
+
+final class SearchableProduct extends Model
+{
+    use Searchable;
+
+    protected $table = 'products';
+
+    protected $guarded = [];
+}


### PR DESCRIPTION
Uses Scout's search to get matching IDs, then constrains the Eloquent query with whereIn. Works with any Scout driver (Typesense, Meilisearch, Algolia, database, collection). Gracefully skips models without the Searchable trait.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bluebeetlept/codesmith/api-toolkit/pr/26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->