### PR TITLE
Simplify FormRequest, PageParser, Resource and harden OpenAPI command

### DIFF
--- a/config/api-toolkit.php
+++ b/config/api-toolkit.php
@@ -58,7 +58,7 @@ return [
         'description' => '',
 
         'servers' => [
-            ['url' => env('APP_URL', 'http://localhost') . '/api'],
+            ['url' => env('APP_URL', 'http://localhost')],
         ],
 
         // 'security_schemes' => [

--- a/src/Console/GenerateOpenApiCommand.php
+++ b/src/Console/GenerateOpenApiCommand.php
@@ -51,7 +51,11 @@ final class GenerateOpenApiCommand extends Command
         $json = json_encode($document, $flags);
         $outputPath = $this->option('output');
 
-        file_put_contents(base_path($outputPath), $json);
+        if (file_put_contents(base_path($outputPath), $json) === false) {
+            $this->error("Failed to write to {$outputPath}");
+
+            return self::FAILURE;
+        }
 
         $this->info("OpenAPI spec written to {$outputPath}");
 

--- a/src/Http/Requests/FormRequest.php
+++ b/src/Http/Requests/FormRequest.php
@@ -68,28 +68,10 @@ class FormRequest extends BaseFormRequest
         $queryRules = $this->queryParamRules();
 
         if (count($queryRules) > 0) {
-            $queryKeys = array_keys($this->query());
-
-            $queryRulesKeys = array_keys($queryRules);
-
-            $invalidQueryKeys = array_values(array_diff($queryKeys, $queryRulesKeys));
-
-            if (count($invalidQueryKeys) > 0) {
-                $message = count($invalidQueryKeys) > 1
-                    ? sprintf(
-                        'Received unknown parameters: %s',
-                        implode(', ', $invalidQueryKeys),
-                    )
-                    : sprintf(
-                        'Received unknown parameter: %s',
-                        $invalidQueryKeys[0],
-                    );
-
-                throw new HttpException(
-                    statusCode: Response::HTTP_BAD_REQUEST,
-                    message: $message,
-                );
-            }
+            $this->rejectUnknownKeys(
+                array_keys($this->query()),
+                array_keys($queryRules),
+            );
 
             /** @var ValidationFactory $factory */
             $factory = $this->container->make(ValidationFactory::class);
@@ -112,28 +94,29 @@ class FormRequest extends BaseFormRequest
         $inputKeys = array_keys(array_diff_key($this->input(), $this->query()));
 
         if (count($inputKeys) > 0) {
-            $rules = $this->rules();
-
-            $rulesKeys = array_keys($rules);
-
-            $invalidInputKeys = array_values(array_diff($inputKeys, $rulesKeys));
-
-            if (count($invalidInputKeys) > 0) {
-                $message = count($invalidInputKeys) > 1
-                    ? sprintf(
-                        'Received unknown parameters: %s',
-                        implode(', ', $invalidInputKeys),
-                    )
-                    : sprintf(
-                        'Received unknown parameter: %s',
-                        $invalidInputKeys[0],
-                    );
-
-                throw new HttpException(
-                    statusCode: Response::HTTP_BAD_REQUEST,
-                    message: $message,
-                );
-            }
+            $this->rejectUnknownKeys($inputKeys, array_keys($this->rules()));
         }
+    }
+
+    /**
+     * @param list<string> $submitted
+     * @param list<string> $allowed
+     */
+    private function rejectUnknownKeys(array $submitted, array $allowed): void
+    {
+        $unknown = array_values(array_diff($submitted, $allowed));
+
+        if ($unknown === []) {
+            return;
+        }
+
+        $message = count($unknown) > 1
+            ? sprintf('Received unknown parameters: %s', implode(', ', $unknown))
+            : sprintf('Received unknown parameter: %s', $unknown[0]);
+
+        throw new HttpException(
+            statusCode: Response::HTTP_BAD_REQUEST,
+            message: $message,
+        );
     }
 }

--- a/src/Parsers/PageParser.php
+++ b/src/Parsers/PageParser.php
@@ -19,11 +19,7 @@ final readonly class PageParser
      */
     public function isCursor(Request $request): bool
     {
-        $page = $request->query('page', []);
-
-        if (! is_array($page)) {
-            return false;
-        }
+        $page = $this->pageArray($request);
 
         return isset($page['cursor']);
     }
@@ -33,12 +29,7 @@ final readonly class PageParser
      */
     public function getSize(Request $request): int
     {
-        $page = $request->query('page', []);
-
-        if (! is_array($page)) {
-            return $this->defaultSize;
-        }
-
+        $page = $this->pageArray($request);
         $size = (int) ($page['size'] ?? $this->defaultSize);
 
         return min(max($size, 1), $this->maxSize);
@@ -49,11 +40,7 @@ final readonly class PageParser
      */
     public function getNumber(Request $request): int
     {
-        $page = $request->query('page', []);
-
-        if (! is_array($page)) {
-            return 1;
-        }
+        $page = $this->pageArray($request);
 
         return max((int) ($page['number'] ?? 1), 1);
     }
@@ -63,12 +50,18 @@ final readonly class PageParser
      */
     public function getCursor(Request $request): string | null
     {
-        $page = $request->query('page', []);
-
-        if (! is_array($page)) {
-            return null;
-        }
+        $page = $this->pageArray($request);
 
         return $page['cursor'] ?? null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function pageArray(Request $request): array
+    {
+        $page = $request->query('page', []);
+
+        return is_array($page) ? $page : [];
     }
 }

--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -297,11 +297,13 @@ class Resource
      */
     private function applySparseFieldsets(string $type, array $attributes): array
     {
+        $parser = new FieldParser();
+
         if ($this->parsedFields === null) {
-            $this->parsedFields = (new FieldParser())->parse($this->request);
+            $this->parsedFields = $parser->parse($this->request);
         }
 
-        return (new FieldParser())->filter($attributes, $this->parsedFields[$type] ?? null);
+        return $parser->filter($attributes, $this->parsedFields[$type] ?? null);
     }
 
     /**


### PR DESCRIPTION
- Extract duplicate unknown parameter rejection into rejectUnknownKeys()
- Extract repeated page array parsing into pageArray()
- Reuse single FieldParser instance in applySparseFieldsets()
- Add error handling for file_put_contents in OpenAPI command

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bluebeetlept/codesmith/api-toolkit/pr/27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->