### PR TITLE
Add output and pretty config options for OpenAPI generator

### DIFF
--- a/config/api-toolkit.php
+++ b/config/api-toolkit.php
@@ -57,6 +57,11 @@ return [
         'version' => '1.0.0',
         'description' => '',
 
+        'output' => [
+            'path' => public_path('openapi.json'),
+            'pretty' => false,
+        ],
+
         'servers' => [
             ['url' => env('APP_URL', 'http://localhost')],
         ],

--- a/src/Console/GenerateOpenApiCommand.php
+++ b/src/Console/GenerateOpenApiCommand.php
@@ -12,7 +12,7 @@ use Illuminate\Contracts\Config\Repository as Config;
 final class GenerateOpenApiCommand extends Command
 {
     protected $signature = 'api-toolkit:openapi
-        {--output=openapi.json : Output file path}
+        {--output= : Output file path}
         {--pretty : Pretty print the JSON output}';
 
     protected $description = 'Generate an OpenAPI 3.1 specification from your API Toolkit resources';
@@ -42,16 +42,20 @@ final class GenerateOpenApiCommand extends Command
 
         $document = $builder->build($endpoints);
 
+        $outputConfig = $openApiConfig['output'] ?? [];
+        $pretty = $this->option('pretty') || (bool) ($outputConfig['pretty'] ?? false);
         $flags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
 
-        if ($this->option('pretty')) {
+        if ($pretty) {
             $flags |= JSON_PRETTY_PRINT;
         }
 
         $json = json_encode($document, $flags);
-        $outputPath = $this->option('output');
+        $outputPath = $this->option('output')
+            ?? $outputConfig['path']
+            ?? public_path('openapi.json');
 
-        if (file_put_contents(base_path($outputPath), $json) === false) {
+        if (file_put_contents($outputPath, $json) === false) {
             $this->error("Failed to write to {$outputPath}");
 
             return self::FAILURE;

--- a/tests/Feature/Console/GenerateOpenApiCommandTest.php
+++ b/tests/Feature/Console/GenerateOpenApiCommandTest.php
@@ -10,8 +10,8 @@ use Illuminate\Support\Facades\Route;
 
 afterEach(function () {
     $files = [
-        base_path('openapi.json'),
-        base_path('custom-output.json'),
+        public_path('openapi.json'),
+        public_path('custom-output.json'),
     ];
 
     foreach ($files as $file) {
@@ -27,7 +27,7 @@ it('warns when no endpoints are found', function () {
         ->assertSuccessful()
     ;
 
-    expect(base_path('openapi.json'))->not->toBeFile();
+    expect(public_path('openapi.json'))->not->toBeFile();
 });
 
 it('generates openapi.json with default output path', function () {
@@ -35,27 +35,29 @@ it('generates openapi.json with default output path', function () {
 
     $this->artisan('api-toolkit:openapi')
         ->expectsOutputToContain('endpoint(s)')
-        ->expectsOutputToContain('OpenAPI spec written to openapi.json')
+        ->expectsOutputToContain('OpenAPI spec written to')
         ->assertSuccessful()
     ;
 
-    expect(base_path('openapi.json'))->toBeFile();
+    expect(public_path('openapi.json'))->toBeFile();
 
-    $content = json_decode(file_get_contents(base_path('openapi.json')), true);
+    $content = json_decode(file_get_contents(public_path('openapi.json')), true);
     expect($content['openapi'])->toBe('3.1.0');
 });
 
 it('generates to custom output path', function () {
     registerRoutes();
 
-    $this->artisan('api-toolkit:openapi', ['--output' => 'custom-output.json'])
-        ->expectsOutputToContain('OpenAPI spec written to custom-output.json')
+    $customPath = public_path('custom-output.json');
+
+    $this->artisan('api-toolkit:openapi', ['--output' => $customPath])
+        ->expectsOutputToContain('OpenAPI spec written to')
         ->assertSuccessful()
     ;
 
-    expect(base_path('custom-output.json'))->toBeFile();
+    expect($customPath)->toBeFile();
 
-    $content = json_decode(file_get_contents(base_path('custom-output.json')), true);
+    $content = json_decode(file_get_contents($customPath), true);
     expect($content['openapi'])->toBe('3.1.0');
 });
 
@@ -66,7 +68,7 @@ it('generates pretty-printed JSON with --pretty flag', function () {
         ->assertSuccessful()
     ;
 
-    $raw = file_get_contents(base_path('openapi.json'));
+    $raw = file_get_contents(public_path('openapi.json'));
     expect($raw)->toContain("\n");
     expect($raw)->toContain('    ');
 });
@@ -78,7 +80,7 @@ it('generates compact JSON without --pretty flag', function () {
         ->assertSuccessful()
     ;
 
-    $raw = file_get_contents(base_path('openapi.json'));
+    $raw = file_get_contents(public_path('openapi.json'));
     expect($raw)->not->toContain("\n");
 });
 
@@ -100,7 +102,7 @@ it('reads openapi config values', function () {
         ->assertSuccessful()
     ;
 
-    $content = json_decode(file_get_contents(base_path('openapi.json')), true);
+    $content = json_decode(file_get_contents(public_path('openapi.json')), true);
     expect($content['info']['title'])->toBe('My Custom API');
     expect($content['info']['version'])->toBe('2.5.0');
     expect($content['info']['description'])->toBe('Custom description');
@@ -119,7 +121,7 @@ it('uses app name as fallback title', function () {
         ->assertSuccessful()
     ;
 
-    $content = json_decode(file_get_contents(base_path('openapi.json')), true);
+    $content = json_decode(file_get_contents(public_path('openapi.json')), true);
     expect($content['info']['title'])->toBe('Fallback App');
 });
 


### PR DESCRIPTION
Output defaults to public_path('openapi.json') so the spec is web-accessible. Both output and pretty can be set in config or overridden via CLI flags.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bluebeetlept/codesmith/api-toolkit/pr/28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->