### PR TITLE
Add BooleanFilter for true/false query parameter filtering

### DIFF
--- a/docs/2.filtering-and-sorting/1.filters.md
+++ b/docs/2.filtering-and-sorting/1.filters.md
@@ -106,6 +106,27 @@ To use a scope name that differs from the filter key, pass it to the constructor
 
 This calls `$query->whereActive($value)` instead of `$query->active($value)`.
 
+### BooleanFilter
+
+Filters by boolean values. Handles the various string representations that come from query parameters: `true`, `false`, `1`, `0`, `yes`, `no` (case insensitive). Invalid values are silently ignored.
+
+```php
+use BlueBeetle\ApiToolkit\Parsers\Filters\BooleanFilter;
+
+public function allowedFilters(): array
+{
+    return [
+        'featured' => new BooleanFilter(),
+    ];
+}
+```
+
+```
+GET /api/products?filter[featured]=true
+GET /api/products?filter[featured]=1
+GET /api/products?filter[featured]=yes
+```
+
 ### SearchFilter
 
 Searches across multiple columns using `LIKE` with OR conditions. Useful for simple search bars that need to match against several fields at once.

--- a/src/Parsers/Filters/BooleanFilter.php
+++ b/src/Parsers/Filters/BooleanFilter.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace BlueBeetle\ApiToolkit\Parsers\Filters;
+
+use Illuminate\Database\Eloquent\Builder;
+
+final readonly class BooleanFilter implements Filter
+{
+    public function apply(Builder $query, string $field, mixed $value): void
+    {
+        $resolved = $this->resolve($value);
+
+        if ($resolved === null) {
+            return;
+        }
+
+        $query->where($field, $resolved);
+    }
+
+    private function resolve(mixed $value): bool | null
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (! is_string($value)) {
+            return null;
+        }
+
+        return match (mb_strtolower($value)) {
+            'true', '1', 'yes' => true,
+            'false', '0', 'no' => false,
+            default => null,
+        };
+    }
+}

--- a/tests/Feature/Parsers/BooleanFilterTest.php
+++ b/tests/Feature/Parsers/BooleanFilterTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace BlueBeetle\ApiToolkit\Tests\Feature\Parsers;
+
+use BlueBeetle\ApiToolkit\Parsers\Filters\BooleanFilter;
+use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\Product;
+
+it('filters by true string value', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Featured', 'code' => 'F01', 'featured' => true]);
+    Product::create(['public_id' => 'p2', 'name' => 'Regular', 'code' => 'R01', 'featured' => false]);
+
+    $filter = new BooleanFilter();
+    $query = Product::query();
+    $filter->apply($query, 'featured', 'true');
+
+    expect($query->get())->toHaveCount(1);
+    expect($query->first()->public_id)->toBe('p1');
+});
+
+it('filters by false string value', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Featured', 'code' => 'F01', 'featured' => true]);
+    Product::create(['public_id' => 'p2', 'name' => 'Regular', 'code' => 'R01', 'featured' => false]);
+
+    $filter = new BooleanFilter();
+    $query = Product::query();
+    $filter->apply($query, 'featured', 'false');
+
+    expect($query->get())->toHaveCount(1);
+    expect($query->first()->public_id)->toBe('p2');
+});
+
+it('accepts 1 and 0 as boolean values', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Featured', 'code' => 'F01', 'featured' => true]);
+    Product::create(['public_id' => 'p2', 'name' => 'Regular', 'code' => 'R01', 'featured' => false]);
+
+    $filter = new BooleanFilter();
+
+    $query = Product::query();
+    $filter->apply($query, 'featured', '1');
+    expect($query->get())->toHaveCount(1);
+    expect($query->first()->public_id)->toBe('p1');
+
+    $query = Product::query();
+    $filter->apply($query, 'featured', '0');
+    expect($query->get())->toHaveCount(1);
+    expect($query->first()->public_id)->toBe('p2');
+});
+
+it('accepts yes and no as boolean values', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Featured', 'code' => 'F01', 'featured' => true]);
+    Product::create(['public_id' => 'p2', 'name' => 'Regular', 'code' => 'R01', 'featured' => false]);
+
+    $filter = new BooleanFilter();
+
+    $query = Product::query();
+    $filter->apply($query, 'featured', 'yes');
+    expect($query->get())->toHaveCount(1);
+    expect($query->first()->public_id)->toBe('p1');
+
+    $query = Product::query();
+    $filter->apply($query, 'featured', 'no');
+    expect($query->get())->toHaveCount(1);
+    expect($query->first()->public_id)->toBe('p2');
+});
+
+it('is case insensitive', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Featured', 'code' => 'F01', 'featured' => true]);
+    Product::create(['public_id' => 'p2', 'name' => 'Regular', 'code' => 'R01', 'featured' => false]);
+
+    $filter = new BooleanFilter();
+    $query = Product::query();
+    $filter->apply($query, 'featured', 'TRUE');
+
+    expect($query->get())->toHaveCount(1);
+    expect($query->first()->public_id)->toBe('p1');
+});
+
+it('accepts actual boolean values', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Featured', 'code' => 'F01', 'featured' => true]);
+    Product::create(['public_id' => 'p2', 'name' => 'Regular', 'code' => 'R01', 'featured' => false]);
+
+    $filter = new BooleanFilter();
+    $query = Product::query();
+    $filter->apply($query, 'featured', true);
+
+    expect($query->get())->toHaveCount(1);
+    expect($query->first()->public_id)->toBe('p1');
+});
+
+it('ignores invalid values', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Featured', 'code' => 'F01', 'featured' => true]);
+    Product::create(['public_id' => 'p2', 'name' => 'Regular', 'code' => 'R01', 'featured' => false]);
+
+    $filter = new BooleanFilter();
+    $query = Product::query();
+    $filter->apply($query, 'featured', 'invalid');
+
+    expect($query->get())->toHaveCount(2);
+});
+
+it('ignores non-string non-boolean values', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Featured', 'code' => 'F01', 'featured' => true]);
+
+    $filter = new BooleanFilter();
+    $query = Product::query();
+    $filter->apply($query, 'featured', ['array']);
+
+    expect($query->get())->toHaveCount(1);
+});
+
+it('works through the query builder', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Featured', 'code' => 'F01', 'featured' => true]);
+    Product::create(['public_id' => 'p2', 'name' => 'Regular', 'code' => 'R01', 'featured' => false]);
+
+    $request = \Illuminate\Http\Request::create('/', 'GET', [
+        'filter' => ['featured' => 'true'],
+    ]);
+
+    $result = \BlueBeetle\ApiToolkit\QueryBuilder::for(Product::class, $request)
+        ->allowedFilters(['featured' => new BooleanFilter()])
+        ->apply()
+        ->getQuery()
+        ->get()
+    ;
+
+    expect($result)->toHaveCount(1);
+    expect($result->first()->name)->toBe('Featured');
+});


### PR DESCRIPTION
Handles string representations from query params: true, false, 1, 0, yes, no (case insensitive). Invalid values are silently ignored.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bluebeetlept/codesmith/api-toolkit/pr/29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->