### PR TITLE
Add ColumnFilter with all operators on a single column

### DIFF
--- a/docs/2.filtering-and-sorting/1.filters.md
+++ b/docs/2.filtering-and-sorting/1.filters.md
@@ -151,6 +151,44 @@ The OR conditions are wrapped in a group, so they don't interfere with other fil
 
 For full-text search powered by Typesense, Meilisearch, or Algolia, see the [Scout integration](/docs/api-toolkit/latest/filtering-and-sorting/scout) page.
 
+### ColumnFilter
+
+A unified filter that supports all operators on a single column. Use this when you want full flexibility without configuring multiple filter types per field.
+
+```php
+use BlueBeetle\ApiToolkit\Parsers\Filters\ColumnFilter;
+
+public function allowedFilters(): array
+{
+    return [
+        'status'      => new ColumnFilter(),
+        'price'       => new ColumnFilter(),
+        'name'        => new ColumnFilter(),
+        'category_id' => new ColumnFilter(),
+    ];
+}
+```
+
+Supported operators:
+
+```
+?filter[status]=active                             → WHERE status = 'active'
+?filter[price][eq]=1000                            → WHERE price = 1000
+?filter[price][neq]=0                              → WHERE price != 0
+?filter[price][gt]=10                              → WHERE price > 10
+?filter[price][gte]=10                             → WHERE price >= 10
+?filter[price][lt]=100                             → WHERE price < 100
+?filter[price][lte]=100                            → WHERE price <= 100
+?filter[price][gte]=10&filter[price][lte]=100      → WHERE price >= 10 AND price <= 100
+?filter[status][in]=active,archived                → WHERE status IN ('active', 'archived')
+?filter[status][not_in]=draft                      → WHERE status NOT IN ('draft')
+?filter[category_id][null]=true                    → WHERE category_id IS NULL
+?filter[category_id][null]=false                   → WHERE category_id IS NOT NULL
+?filter[name][like]=widget                         → WHERE name LIKE '%widget%'
+```
+
+When a scalar value is passed (no operator), it defaults to exact match. Unknown operators are silently ignored. Multiple operators on the same field are combined with AND.
+
 ## Custom Filters
 
 Implement the `Filter` interface to create your own:

--- a/src/Parsers/Filters/ColumnFilter.php
+++ b/src/Parsers/Filters/ColumnFilter.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace BlueBeetle\ApiToolkit\Parsers\Filters;
+
+use Illuminate\Database\Eloquent\Builder;
+
+final readonly class ColumnFilter implements Filter
+{
+    private const array OPERATORS = [
+        'eq' => '=',
+        'neq' => '!=',
+        'gt' => '>',
+        'gte' => '>=',
+        'lt' => '<',
+        'lte' => '<=',
+    ];
+
+    public function apply(Builder $query, string $field, mixed $value): void
+    {
+        if (! is_array($value)) {
+            $this->applyScalar($query, $field, $value);
+
+            return;
+        }
+
+        foreach ($value as $operator => $operand) {
+            if (! is_string($operator)) {
+                continue;
+            }
+
+            match ($operator) {
+                'eq', 'neq', 'gt', 'gte', 'lt', 'lte' => $query->where($field, self::OPERATORS[$operator], $operand),
+                'in' => $query->whereIn($field, $this->toList($operand)),
+                'not_in' => $query->whereNotIn($field, $this->toList($operand)),
+                'null' => $this->applyNull($query, $field, $operand),
+                'like' => $query->where($field, 'LIKE', '%'.$operand.'%'),
+                default => null,
+            };
+        }
+    }
+
+    private function applyScalar(Builder $query, string $field, mixed $value): void
+    {
+        if (! is_string($value) && ! is_int($value) && ! is_float($value)) {
+            return;
+        }
+
+        $query->where($field, '=', $value);
+    }
+
+    private function applyNull(Builder $query, string $field, mixed $value): void
+    {
+        $isNull = $this->resolveBool($value);
+
+        if ($isNull === null) {
+            return;
+        }
+
+        $isNull ? $query->whereNull($field) : $query->whereNotNull($field);
+    }
+
+    private function resolveBool(mixed $value): bool | null
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (! is_string($value)) {
+            return null;
+        }
+
+        return match (mb_strtolower($value)) {
+            'true', '1', 'yes' => true,
+            'false', '0', 'no' => false,
+            default => null,
+        };
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function toList(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (! is_string($value) || $value === '') {
+            return [];
+        }
+
+        return array_map('trim', explode(',', $value));
+    }
+}

--- a/tests/Feature/Parsers/ColumnFilterTest.php
+++ b/tests/Feature/Parsers/ColumnFilterTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace BlueBeetle\ApiToolkit\Tests\Feature\Parsers;
+
+use BlueBeetle\ApiToolkit\Parsers\Filters\ColumnFilter;
+use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\Product;
+
+// Scalar (exact match)
+
+it('filters by exact scalar value', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01', 'status' => 'active']);
+    Product::create(['public_id' => 'p2', 'name' => 'Gadget', 'code' => 'G01', 'status' => 'draft']);
+
+    $filter = new ColumnFilter();
+    $query = Product::query();
+    $filter->apply($query, 'status', 'active');
+
+    expect($query->get())->toHaveCount(1);
+    expect($query->first()->public_id)->toBe('p1');
+});
+
+// Comparison operators
+
+it('filters with eq operator', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01', 'price_in_cents' => 1000]);
+    Product::create(['public_id' => 'p2', 'name' => 'Gadget', 'code' => 'G01', 'price_in_cents' => 2000]);
+
+    $filter = new ColumnFilter();
+    $query = Product::query();
+    $filter->apply($query, 'price_in_cents', ['eq' => 1000]);
+
+    expect($query->get())->toHaveCount(1);
+    expect($query->first()->public_id)->toBe('p1');
+});
+
+it('filters with neq operator', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01', 'price_in_cents' => 1000]);
+    Product::create(['public_id' => 'p2', 'name' => 'Gadget', 'code' => 'G01', 'price_in_cents' => 2000]);
+
+    $filter = new ColumnFilter();
+    $query = Product::query();
+    $filter->apply($query, 'price_in_cents', ['neq' => 1000]);
+
+    expect($query->get())->toHaveCount(1);
+    expect($query->first()->public_id)->toBe('p2');
+});
+
+it('filters with range operators', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Cheap', 'code' => 'C01', 'price_in_cents' => 500]);
+    Product::create(['public_id' => 'p2', 'name' => 'Mid', 'code' => 'M01', 'price_in_cents' => 1000]);
+    Product::create(['public_id' => 'p3', 'name' => 'Expensive', 'code' => 'E01', 'price_in_cents' => 5000]);
+
+    $filter = new ColumnFilter();
+    $query = Product::query();
+    $filter->apply($query, 'price_in_cents', ['gte' => 500, 'lte' => 1000]);
+
+    expect($query->get())->toHaveCount(2);
+});
+
+it('filters with gt and lt operators', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Cheap', 'code' => 'C01', 'price_in_cents' => 500]);
+    Product::create(['public_id' => 'p2', 'name' => 'Mid', 'code' => 'M01', 'price_in_cents' => 1000]);
+    Product::create(['public_id' => 'p3', 'name' => 'Expensive', 'code' => 'E01', 'price_in_cents' => 5000]);
+
+    $filter = new ColumnFilter();
+    $query = Product::query();
+    $filter->apply($query, 'price_in_cents', ['gt' => 500, 'lt' => 5000]);
+
+    expect($query->get())->toHaveCount(1);
+    expect($query->first()->public_id)->toBe('p2');
+});
+
+// IN / NOT IN
+
+it('filters with in operator using comma-separated string', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Active', 'code' => 'A01', 'status' => 'active']);
+    Product::create(['public_id' => 'p2', 'name' => 'Archived', 'code' => 'A02', 'status' => 'archived']);
+    Product::create(['public_id' => 'p3', 'name' => 'Draft', 'code' => 'D01', 'status' => 'draft']);
+
+    $filter = new ColumnFilter();
+    $query = Product::query();
+    $filter->apply($query, 'status', ['in' => 'active,archived']);
+
+    expect($query->get())->toHaveCount(2);
+});
+
+it('filters with in operator using array', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Active', 'code' => 'A01', 'status' => 'active']);
+    Product::create(['public_id' => 'p2', 'name' => 'Draft', 'code' => 'D01', 'status' => 'draft']);
+
+    $filter = new ColumnFilter();
+    $query = Product::query();
+    $filter->apply($query, 'status', ['in' => ['active']]);
+
+    expect($query->get())->toHaveCount(1);
+    expect($query->first()->public_id)->toBe('p1');
+});
+
+it('filters with not_in operator', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Active', 'code' => 'A01', 'status' => 'active']);
+    Product::create(['public_id' => 'p2', 'name' => 'Archived', 'code' => 'A02', 'status' => 'archived']);
+    Product::create(['public_id' => 'p3', 'name' => 'Draft', 'code' => 'D01', 'status' => 'draft']);
+
+    $filter = new ColumnFilter();
+    $query = Product::query();
+    $filter->apply($query, 'status', ['not_in' => 'archived,draft']);
+
+    expect($query->get())->toHaveCount(1);
+    expect($query->first()->public_id)->toBe('p1');
+});
+
+// NULL
+
+it('filters where field is null', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'With', 'code' => 'C01', 'category_id' => 1]);
+    Product::create(['public_id' => 'p2', 'name' => 'Without', 'code' => 'C02', 'category_id' => null]);
+
+    $filter = new ColumnFilter();
+    $query = Product::query();
+    $filter->apply($query, 'category_id', ['null' => 'true']);
+
+    expect($query->get())->toHaveCount(1);
+    expect($query->first()->public_id)->toBe('p2');
+});
+
+it('filters where field is not null', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'With', 'code' => 'C01', 'category_id' => 1]);
+    Product::create(['public_id' => 'p2', 'name' => 'Without', 'code' => 'C02', 'category_id' => null]);
+
+    $filter = new ColumnFilter();
+    $query = Product::query();
+    $filter->apply($query, 'category_id', ['null' => 'false']);
+
+    expect($query->get())->toHaveCount(1);
+    expect($query->first()->public_id)->toBe('p1');
+});
+
+// LIKE
+
+it('filters with like operator', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Widget Pro', 'code' => 'W01']);
+    Product::create(['public_id' => 'p2', 'name' => 'Gadget', 'code' => 'G01']);
+
+    $filter = new ColumnFilter();
+    $query = Product::query();
+    $filter->apply($query, 'name', ['like' => 'widget']);
+
+    expect($query->get())->toHaveCount(1);
+    expect($query->first()->public_id)->toBe('p1');
+});
+
+// Combined operators on same field
+
+it('combines multiple operators on same field', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Cheap', 'code' => 'C01', 'price_in_cents' => 500]);
+    Product::create(['public_id' => 'p2', 'name' => 'Mid', 'code' => 'M01', 'price_in_cents' => 1000]);
+    Product::create(['public_id' => 'p3', 'name' => 'Expensive', 'code' => 'E01', 'price_in_cents' => 5000]);
+
+    $filter = new ColumnFilter();
+    $query = Product::query();
+    $filter->apply($query, 'price_in_cents', ['gte' => 1000, 'lte' => 3000]);
+
+    expect($query->get())->toHaveCount(1);
+    expect($query->first()->public_id)->toBe('p2');
+});
+
+it('applies filters across different fields', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Cheap', 'code' => 'C01', 'price_in_cents' => 500, 'category_id' => 1]);
+    Product::create(['public_id' => 'p2', 'name' => 'Mid', 'code' => 'M01', 'price_in_cents' => 1000, 'category_id' => null]);
+    Product::create(['public_id' => 'p3', 'name' => 'Expensive', 'code' => 'E01', 'price_in_cents' => 5000, 'category_id' => 1]);
+
+    $filter = new ColumnFilter();
+    $query = Product::query();
+    $filter->apply($query, 'price_in_cents', ['gte' => 1000]);
+    $filter->apply($query, 'category_id', ['null' => 'false']);
+
+    expect($query->get())->toHaveCount(1);
+    expect($query->first()->public_id)->toBe('p3');
+});
+
+// Edge cases
+
+it('ignores unknown operators', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01', 'price_in_cents' => 1000]);
+
+    $filter = new ColumnFilter();
+    $query = Product::query();
+    $filter->apply($query, 'price_in_cents', ['invalid' => 500]);
+
+    expect($query->get())->toHaveCount(1);
+});
+
+it('ignores non-string non-numeric scalar values', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01']);
+
+    $filter = new ColumnFilter();
+    $query = Product::query();
+    $filter->apply($query, 'name', true);
+
+    expect($query->get())->toHaveCount(1);
+});
+
+// QueryBuilder integration
+
+it('works through the query builder with mixed operators', function () {
+    Product::create(['public_id' => 'p1', 'name' => 'Cheap Active', 'code' => 'C01', 'price_in_cents' => 500, 'status' => 'active']);
+    Product::create(['public_id' => 'p2', 'name' => 'Mid Active', 'code' => 'M01', 'price_in_cents' => 1500, 'status' => 'active']);
+    Product::create(['public_id' => 'p3', 'name' => 'Expensive Draft', 'code' => 'E01', 'price_in_cents' => 5000, 'status' => 'draft']);
+
+    $request = \Illuminate\Http\Request::create('/', 'GET', [
+        'filter' => [
+            'price_in_cents' => ['gte' => 1000, 'lte' => 5000],
+            'status' => 'active',
+        ],
+    ]);
+
+    $result = \BlueBeetle\ApiToolkit\QueryBuilder::for(Product::class, $request)
+        ->allowedFilters([
+            'price_in_cents' => new ColumnFilter(),
+            'status' => new ColumnFilter(),
+        ])
+        ->apply()
+        ->getQuery()
+        ->get()
+    ;
+
+    expect($result)->toHaveCount(1);
+    expect($result->first()->public_id)->toBe('p2');
+});


### PR DESCRIPTION
Unified filter supporting eq, neq, gt, gte, lt, lte, in, not_in, null, and like operators.

Scalar values default to exact match.

Multiple operators on the same field combine with AND.

Keeps individual filters for when explicit restriction is needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bluebeetlept/codesmith/api-toolkit/pr/32"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->