### PR TITLE
Add Resource::map() for model-to-resource auto-resolution

### DIFF
--- a/docs/1.basics/1.resources.md
+++ b/docs/1.basics/1.resources.md
@@ -100,6 +100,50 @@ Resource::resolveTypeUsing(fn ($model) => Str::kebab(class_basename($model)));
 | 4 | `$model->id` property | Class name (snake-cased) |
 | 5 | Throws `RuntimeException` | Empty string |
 
+## Resource Map
+
+Register a model-to-resource map so you don't have to pass the resource class on every call. This works with both `Response::success()` and `QueryBuilder`:
+
+```php
+// In a service provider boot() method
+use App\Http\Resources\ClientResource;
+use App\Http\Resources\ProductResource;
+use App\Models\Client;
+use App\Models\Product;
+use BlueBeetle\ApiToolkit\Resources\Resource;
+
+Resource::map([
+    Product::class => ProductResource::class,
+    Client::class => ClientResource::class,
+]);
+```
+
+With the map registered, the resource parameter becomes optional:
+
+```php
+use App\Models\Product;
+use BlueBeetle\ApiToolkit\Http\Response;
+use BlueBeetle\ApiToolkit\QueryBuilder;
+use Illuminate\Http\Request;
+
+class ProductController
+{
+    public function index(Request $request)
+    {
+        // No fromResource() needed - resolved from the map
+        return QueryBuilder::for(Product::class, $request)->paginate();
+    }
+
+    public function show(Product $product, Response $response)
+    {
+        // No resource class needed - resolved from the map
+        return $response->success($product);
+    }
+}
+```
+
+The map works for single models, collections, and paginated results. When an explicit resource class is provided, it always takes precedence over the map.
+
 ## Relationships
 
 Define relationships by mapping names to resource classes:

--- a/src/Http/SuccessResponse.php
+++ b/src/Http/SuccessResponse.php
@@ -88,23 +88,25 @@ final class SuccessResponse implements \Illuminate\Contracts\Support\Responsable
             return $this->envelope(['data' => null]);
         }
 
-        if ($this->resource === null) {
+        $resource = $this->resource ?? $this->resolveResourceFromData();
+
+        if ($resource === null) {
             return $this->envelope(['data' => $this->data]);
         }
 
         if ($this->isCollection()) {
             $collection = new ResourceCollection(
                 data: $this->data,
-                resourceClass: $this->resource,
+                resourceClass: $resource,
                 request: $this->request,
             );
 
             return $this->envelope($collection->toArray());
         }
 
-        $resource = app($this->resource)->withRequest($this->request);
+        $resourceInstance = app($resource)->withRequest($this->request);
 
-        $result = ['data' => $resource->toArray($this->data)];
+        $result = ['data' => $resourceInstance->toArray($this->data)];
 
         return $this->envelope($result);
     }
@@ -125,6 +127,29 @@ final class SuccessResponse implements \Illuminate\Contracts\Support\Responsable
         }
 
         return $result;
+    }
+
+    /**
+     * @return class-string<resource>|null
+     */
+    private function resolveResourceFromData(): string | null
+    {
+        $item = $this->data;
+
+        if ($item instanceof LengthAwarePaginator || $item instanceof CursorPaginator) {
+            $items = $item->items();
+            $item = $items[0] ?? null;
+        } elseif ($item instanceof Collection || $item instanceof EloquentCollection) {
+            $item = $item->first();
+        } elseif (is_array($item)) {
+            $item = $item[0] ?? null;
+        }
+
+        if ($item === null) {
+            return null;
+        }
+
+        return Resource::resolveResourceClass($item);
     }
 
     private function isCollection(): bool

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -204,8 +204,12 @@ final class QueryBuilder
             return $this->resourceInstance;
         }
 
-        if ($this->resourceClass !== null) {
-            $this->resourceInstance = app($this->resourceClass)->withRequest($this->request);
+        $resourceClass = $this->resourceClass
+            ?? Resource::resolveResourceClass($this->query->getModel());
+
+        if ($resourceClass !== null) {
+            $this->resourceClass = $resourceClass;
+            $this->resourceInstance = app($resourceClass)->withRequest($this->request);
 
             return $this->resourceInstance;
         }

--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -36,6 +36,13 @@ class Resource
     private static Closure | null $typeResolver = null;
 
     /**
+     * Model-to-resource class map.
+     *
+     * @var array<class-string, class-string<resource>>
+     */
+    private static array $resourceMap = [];
+
+    /**
      * The model class this resource represents.
      * When set to an Eloquent model, the JSON:API type is derived from its table name.
      *
@@ -81,12 +88,35 @@ class Resource
     }
 
     /**
-     * Reset global resolvers (useful for testing).
+     * Register a model-to-resource class map.
+     *
+     * @param array<class-string, class-string<resource>> $map
+     */
+    public static function map(array $map): void
+    {
+        self::$resourceMap = array_merge(self::$resourceMap, $map);
+    }
+
+    /**
+     * Resolve the resource class for a given model or class name.
+     *
+     * @return class-string<resource>|null
+     */
+    public static function resolveResourceClass(mixed $model): string | null
+    {
+        $class = is_object($model) ? $model::class : $model;
+
+        return self::$resourceMap[$class] ?? null;
+    }
+
+    /**
+     * Reset global resolvers and resource map (useful for testing).
      */
     public static function resetResolvers(): void
     {
         self::$idResolver = null;
         self::$typeResolver = null;
+        self::$resourceMap = [];
     }
 
     public static function make(mixed ...$data): array | null

--- a/tests/Feature/Resources/ResourceMapTest.php
+++ b/tests/Feature/Resources/ResourceMapTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace BlueBeetle\ApiToolkit\Tests\Feature\Resources;
+
+use BlueBeetle\ApiToolkit\Http\Response;
+use BlueBeetle\ApiToolkit\Http\SuccessResponse;
+use BlueBeetle\ApiToolkit\QueryBuilder;
+use BlueBeetle\ApiToolkit\Resources\Resource;
+use BlueBeetle\ApiToolkit\Tests\Fixtures\Models\Product;
+use BlueBeetle\ApiToolkit\Tests\Fixtures\Resources\ProductResource;
+use Illuminate\Http\Request;
+
+afterEach(function () {
+    Resource::resetResolvers();
+});
+
+it('registers a resource map', function () {
+    Resource::map([
+        Product::class => ProductResource::class,
+    ]);
+
+    expect(Resource::resolveResourceClass(Product::class))->toBe(ProductResource::class);
+});
+
+it('resolves resource class from model instance', function () {
+    Resource::map([
+        Product::class => ProductResource::class,
+    ]);
+
+    $product = new Product();
+
+    expect(Resource::resolveResourceClass($product))->toBe(ProductResource::class);
+});
+
+it('returns null for unmapped models', function () {
+    expect(Resource::resolveResourceClass(Product::class))->toBeNull();
+});
+
+it('resets resource map with resetResolvers', function () {
+    Resource::map([
+        Product::class => ProductResource::class,
+    ]);
+
+    Resource::resetResolvers();
+
+    expect(Resource::resolveResourceClass(Product::class))->toBeNull();
+});
+
+it('merges multiple map calls', function () {
+    Resource::map([
+        Product::class => ProductResource::class,
+    ]);
+
+    Resource::map([
+        'App\Models\Category' => 'App\Http\Resources\CategoryResource',
+    ]);
+
+    expect(Resource::resolveResourceClass(Product::class))->toBe(ProductResource::class);
+    expect(Resource::resolveResourceClass('App\Models\Category'))->toBe('App\Http\Resources\CategoryResource');
+});
+
+it('auto-resolves resource in SuccessResponse for single model', function () {
+    Resource::map([
+        Product::class => ProductResource::class,
+    ]);
+
+    $product = Product::create([
+        'public_id' => 'p1',
+        'name' => 'Widget',
+        'code' => 'W01',
+        'price_in_cents' => 1000,
+        'featured' => false,
+    ]);
+
+    $response = new Response();
+    $result = $response->success($product)->respond();
+    $data = json_decode($result->getContent(), true);
+
+    expect($data['data']['type'])->toBe('products');
+    expect($data['data']['attributes']['name'])->toBe('Widget');
+});
+
+it('auto-resolves resource in SuccessResponse for collection', function () {
+    Resource::map([
+        Product::class => ProductResource::class,
+    ]);
+
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01', 'price_in_cents' => 1000, 'featured' => false]);
+    Product::create(['public_id' => 'p2', 'name' => 'Gadget', 'code' => 'G01', 'price_in_cents' => 2000, 'featured' => false]);
+
+    $response = new Response();
+    $result = $response->success(Product::all())->respond();
+    $data = json_decode($result->getContent(), true);
+
+    expect($data['data'])->toHaveCount(2);
+    expect($data['data'][0]['type'])->toBe('products');
+});
+
+it('auto-resolves resource in QueryBuilder', function () {
+    Resource::map([
+        Product::class => ProductResource::class,
+    ]);
+
+    Product::create(['public_id' => 'p1', 'name' => 'Widget', 'code' => 'W01', 'price_in_cents' => 1000, 'featured' => false]);
+
+    $request = Request::create('/');
+
+    $result = QueryBuilder::for(Product::class, $request)->paginate();
+
+    expect($result)->toBeInstanceOf(SuccessResponse::class);
+
+    $array = $result->toArray();
+    expect($array['data'])->toHaveCount(1);
+    expect($array['data'][0]['type'])->toBe('products');
+});
+
+it('explicit resource class takes precedence over map', function () {
+    Resource::map([
+        Product::class => ProductResource::class,
+    ]);
+
+    $product = Product::create([
+        'public_id' => 'p1',
+        'name' => 'Widget',
+        'code' => 'W01',
+        'price_in_cents' => 1000,
+        'featured' => false,
+    ]);
+
+    $response = new Response();
+    $result = $response->success($product, ProductResource::class)->respond();
+    $data = json_decode($result->getContent(), true);
+
+    expect($data['data']['type'])->toBe('products');
+});
+
+it('returns raw data when model is not mapped and no resource provided', function () {
+    $response = new Response();
+    $result = $response->success(['raw' => 'data'])->respond();
+    $data = json_decode($result->getContent(), true);
+
+    expect($data['data'])->toBe(['raw' => 'data']);
+});


### PR DESCRIPTION
Register a map of model classes to resource classes so the resource parameter becomes optional on success() and fromResource() calls.

The QueryBuilder and SuccessResponse auto-resolve the resource from the map when not explicitly provided. Explicit resource class always takes precedence.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bluebeetlept/codesmith/api-toolkit/pr/35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->