### PR TITLE
Fix resolveResourceClass crash when data is an array

### DIFF
--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -104,6 +104,10 @@ class Resource
      */
     public static function resolveResourceClass(mixed $model): string | null
     {
+        if (! is_object($model) && ! is_string($model)) {
+            return null;
+        }
+
         $class = is_object($model) ? $model::class : $model;
 
         return self::$resourceMap[$class] ?? null;

--- a/tests/Feature/Resources/ResourceMapTest.php
+++ b/tests/Feature/Resources/ResourceMapTest.php
@@ -48,6 +48,12 @@ it('resets resource map with resetResolvers', function () {
     expect(Resource::resolveResourceClass(Product::class))->toBeNull();
 });
 
+it('returns null for non-object non-string values', function () {
+    expect(Resource::resolveResourceClass(['raw' => 'data']))->toBeNull();
+    expect(Resource::resolveResourceClass(123))->toBeNull();
+    expect(Resource::resolveResourceClass(null))->toBeNull();
+});
+
 it('merges multiple map calls', function () {
     Resource::map([
         Product::class => ProductResource::class,


### PR DESCRIPTION
Return null for non-object, non-string values instead of attempting to access ::class on arrays or scalars.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bluebeetlept/codesmith/api-toolkit/pr/36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->