### PR TITLE
Add withStatus() and withHeaders() to SuccessResponse

### DIFF
--- a/docs/1.basics/2.responses.md
+++ b/docs/1.basics/2.responses.md
@@ -100,22 +100,33 @@ class ProductController
 
 ### Custom Status Code and Headers
 
+Use `withStatus()` and `withHeaders()` to customize the HTTP response while keeping the `Responsable` return type:
+
 ```php
 use App\Http\Resources\ProductResource;
 use App\Models\Product;
 use BlueBeetle\ApiToolkit\Http\Response;
+use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\Request;
 
 class ProductController
 {
-    public function store(Request $request, Response $response)
+    public function store(Request $request, Response $response): Responsable
     {
         $product = Product::create($request->validated());
 
         return $response->success($product, ProductResource::class)
-            ->respond(201, ['X-Custom-Header' => 'value']);
+            ->withStatus(201)
+            ->withHeaders(['X-Custom-Header' => 'value']);
     }
 }
+```
+
+Alternatively, call `respond()` directly to get a `JsonResponse`:
+
+```php
+return $response->success($product, ProductResource::class)
+    ->respond(201, ['X-Custom-Header' => 'value']);
 ```
 
 ### Raw Array Data

--- a/src/Http/SuccessResponse.php
+++ b/src/Http/SuccessResponse.php
@@ -27,6 +27,13 @@ final class SuccessResponse implements \Illuminate\Contracts\Support\Responsable
 
     private Request | null $request = null;
 
+    private int $status = 200;
+
+    /**
+     * @var array<string, string>
+     */
+    private array $headers = [];
+
     /**
      * @param class-string<resource>|null $resource
      */
@@ -63,9 +70,26 @@ final class SuccessResponse implements \Illuminate\Contracts\Support\Responsable
         return $this;
     }
 
+    public function withStatus(int $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, string> $headers
+     */
+    public function withHeaders(array $headers): self
+    {
+        $this->headers = array_merge($this->headers, $headers);
+
+        return $this;
+    }
+
     public function toResponse($request): JsonResponse
     {
-        return $this->respond();
+        return $this->respond($this->status, $this->headers);
     }
 
     public function respond(int $status = 200, array $headers = []): JsonResponse

--- a/tests/Feature/Response/ResponseTest.php
+++ b/tests/Feature/Response/ResponseTest.php
@@ -221,6 +221,44 @@ it('omits optional fields when not set in error response', function () {
     expect($error)->not->toHaveKey('meta');
 });
 
+it('creates a success response with withStatus for Responsable flow', function () {
+    $response = new Response();
+
+    $successResponse = $response->success(['status' => 'generating'])->withStatus(202);
+    $result = $successResponse->toResponse(Request::create('/'));
+
+    expect($result->getStatusCode())->toBe(202);
+    expect($result->headers->get('Content-Type'))->toBe('application/vnd.api+json');
+
+    $data = json_decode($result->getContent(), true);
+    expect($data['data']['status'])->toBe('generating');
+});
+
+it('creates a success response with withHeaders for Responsable flow', function () {
+    $response = new Response();
+
+    $successResponse = $response->success(['test' => true])
+        ->withHeaders(['X-Request-Id' => 'req-456'])
+    ;
+    $result = $successResponse->toResponse(Request::create('/'));
+
+    expect($result->headers->get('X-Request-Id'))->toBe('req-456');
+    expect($result->headers->get('Content-Type'))->toBe('application/vnd.api+json');
+});
+
+it('creates a success response with withStatus and withHeaders combined', function () {
+    $response = new Response();
+
+    $successResponse = $response->success(['message' => 'accepted'])
+        ->withStatus(202)
+        ->withHeaders(['X-Custom' => 'value'])
+    ;
+    $result = $successResponse->toResponse(Request::create('/'));
+
+    expect($result->getStatusCode())->toBe(202);
+    expect($result->headers->get('X-Custom'))->toBe('value');
+});
+
 it('creates a 204 no content response with empty body', function () {
     $response = new Response();
 


### PR DESCRIPTION
Allows setting custom HTTP status codes and headers while keeping the `Responsable` return type, instead of having to call `respond()` which returns `JsonResponse` directly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bluebeetlept/codesmith/api-toolkit/pr/37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782048501&installation_id=127548263&pr_number=37&repository=bluebeetlept%2Fapi-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fbluebeetlept%2Fapi-toolkit%2Fpull%2F37&signature=b6ec29ca044ff0ae831aca68a4b6efda20a05bc29852d570a310b5e5258c7971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->