### PR TITLE
Fix response for unresolvable empty paginators

### DIFF
--- a/src/Http/SuccessResponse.php
+++ b/src/Http/SuccessResponse.php
@@ -115,6 +115,10 @@ final class SuccessResponse implements \Illuminate\Contracts\Support\Responsable
         $resource = $this->resource ?? $this->resolveResourceFromData();
 
         if ($resource === null) {
+            if ($this->isPaginator()) {
+                return $this->envelope($this->buildRawCollectionResponse());
+            }
+
             return $this->envelope(['data' => $this->data]);
         }
 
@@ -154,6 +158,52 @@ final class SuccessResponse implements \Illuminate\Contracts\Support\Responsable
     }
 
     /**
+     * @return array<string, mixed>
+     */
+    private function buildRawCollectionResponse(): array
+    {
+        $result = [];
+
+        if ($this->data instanceof LengthAwarePaginator) {
+            $result['data'] = array_values($this->data->items());
+            $result['meta'] = [
+                'page' => [
+                    'currentPage' => $this->data->currentPage(),
+                    'lastPage' => $this->data->lastPage(),
+                    'perPage' => $this->data->perPage(),
+                    'total' => $this->data->total(),
+                ],
+            ];
+            $result['links'] = [
+                'first' => $this->data->url(1),
+                'last' => $this->data->url($this->data->lastPage()),
+                'prev' => $this->data->previousPageUrl(),
+                'next' => $this->data->nextPageUrl(),
+            ];
+        } elseif ($this->data instanceof CursorPaginator) {
+            $result['data'] = array_values($this->data->items());
+            $result['meta'] = [
+                'page' => [
+                    'perPage' => $this->data->perPage(),
+                    'hasMore' => $this->data->hasMorePages(),
+                ],
+            ];
+            $result['links'] = [
+                'prev' => $this->data->previousPageUrl(),
+                'next' => $this->data->nextPageUrl(),
+            ];
+        } else {
+            $items = $this->data instanceof Collection || $this->data instanceof EloquentCollection
+                ? $this->data->all()
+                : $this->data;
+
+            $result['data'] = array_values((array) $items);
+        }
+
+        return $result;
+    }
+
+    /**
      * @return class-string<resource>|null
      */
     private function resolveResourceFromData(): string | null
@@ -178,10 +228,15 @@ final class SuccessResponse implements \Illuminate\Contracts\Support\Responsable
 
     private function isCollection(): bool
     {
-        return $this->data instanceof LengthAwarePaginator
-            || $this->data instanceof CursorPaginator
+        return $this->isPaginator()
             || $this->data instanceof Collection
             || $this->data instanceof EloquentCollection
             || is_array($this->data);
+    }
+
+    private function isPaginator(): bool
+    {
+        return $this->data instanceof LengthAwarePaginator
+            || $this->data instanceof CursorPaginator;
     }
 }

--- a/tests/Feature/Resources/ResourceMapTest.php
+++ b/tests/Feature/Resources/ResourceMapTest.php
@@ -122,6 +122,49 @@ it('auto-resolves resource in QueryBuilder', function () {
     expect($array['data'][0]['type'])->toBe('products');
 });
 
+it('auto-resolves resource for empty paginator', function () {
+    Resource::map([
+        Product::class => ProductResource::class,
+    ]);
+
+    $request = Request::create('/');
+
+    $result = QueryBuilder::for(Product::class, $request)->paginate();
+
+    $array = $result->toArray();
+    expect($array['data'])->toBe([]);
+    expect($array['meta']['page']['total'])->toBe(0);
+});
+
+it('auto-resolves resource for empty paginator via QueryBuilder', function () {
+    Resource::map([
+        Product::class => ProductResource::class,
+    ]);
+
+    $request = Request::create('/');
+    $result = QueryBuilder::for(Product::class, $request)->paginate();
+
+    $array = $result->toArray();
+    expect($array['data'])->toBe([]);
+    expect($array['meta']['page']['total'])->toBe(0);
+});
+
+it('returns proper JSON:API structure for unresolvable empty paginator', function () {
+    // No resource map - can't resolve from empty paginator
+    $paginator = new \Illuminate\Pagination\LengthAwarePaginator([], 0, 20, 1);
+
+    $response = new Response();
+    $result = $response->success($paginator)->respond();
+    $data = json_decode($result->getContent(), true);
+
+    expect($data['data'])->toBe([]);
+    expect($data['meta']['page']['total'])->toBe(0);
+    expect($data['meta']['page']['currentPage'])->toBe(1);
+    expect($data['meta']['page']['perPage'])->toBe(20);
+    expect($data['links'])->toHaveKey('first');
+    expect($data['links'])->toHaveKey('last');
+});
+
 it('explicit resource class takes precedence over map', function () {
     Resource::map([
         Product::class => ProductResource::class,


### PR DESCRIPTION
When a paginator has no items and the resource can't be auto-resolved, return a proper JSON:API structure with empty data array, pagination meta, and links instead of dumping the raw paginator object.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bluebeetlept/codesmith/api-toolkit/pr/38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782303809&installation_id=127548263&pr_number=38&repository=bluebeetlept%2Fapi-toolkit&return_to=https%3A%2F%2Fgithub.com%2Fbluebeetlept%2Fapi-toolkit%2Fpull%2F38&signature=e92cae6a16c94694dbf7d4db5272fa060aa11f9e713e674f97718775b6d664c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->